### PR TITLE
feat: add safe macOS and Linux support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 *.bat text eol=crlf
 *.ps1 text eol=crlf
 *.sh text eol=lf
+*.command text eol=lf
 *.py text eol=lf
 *.ts text eol=lf
 *.vue text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,15 @@ concurrency:
 
 jobs:
   backend-and-launchers:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            venv-python: "backend\\.venv\\Scripts\\python.exe"
+          - os: macos-latest
+            venv-python: "backend/.venv/bin/python"
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -41,11 +49,14 @@ jobs:
       - name: Test backend
         working-directory: backend
         run: uv run pytest tests -q
+      - name: Install Redis for POSIX launcher check
+        if: runner.os == 'macOS'
+        run: brew install redis
       - name: Prepare frontend dependencies for launcher check
         working-directory: frontend
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Test Windows launchers and repository contracts
-        run: backend\.venv\Scripts\python.exe -m pytest tests -q
+      - name: Test launchers and repository contracts
+        run: ${{ matrix.venv-python }} -m pytest tests -q
 
   frontend:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,16 @@ uv sync
 # 启动开发服务器（需要先启动 Redis）
 ENV=DEV uvicorn app.main:app --host 0.0.0.0 --port 18000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload
 
-# 测试
-.\.venv\Scripts\python.exe -m pytest tests -q
-
-# Lint
-.\.venv\Scripts\python.exe -m ruff check app
+# 测试与 Lint（Windows 将 .venv/bin/python 换成 .venv\Scripts\python.exe）
+.venv/bin/python -m pytest tests -q
+.venv/bin/python -m ruff check app
 ```
+
+### 一键启动服务（Redis + 后端 + 前端）
+
+- macOS / Linux：`bash tools/start_services.sh`（`--check` 只校验依赖），
+  停止用 `bash tools/stop_services.sh`；Windows 用 `win_start.bat` / `win_stop.bat`。
+- 端口契约固定：Redis 16379 / 后端 18000 / 前端 15173。
 
 ### 前端
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ Remit 把题面理解、数据检查、文献研究、模型选择、代码执�
 
 ## 运行要求
 
-- Windows 10/11（桌面启动器）或支持 Docker Compose 的系统；
+- Windows 10/11（桌面启动器）、macOS 12+（脚本启动）或支持 Docker Compose 的系统；
 - Python 3.12+ 与 [uv](https://docs.astral.sh/uv/)；
 - Node.js 20+ 与 pnpm 10；
-- 完整工作流需要 Redis。Windows 源码模式可使用仓库内置的 Redis 运行文件。
+- 完整工作流需要 Redis。Windows 源码模式可使用仓库内置的 Redis 运行文件；
+  macOS 通过 `brew install redis` 安装，启动脚本会在 16379 端口拉起一个
+  Remit 专属的 Redis 实例，不影响系统已有 Redis。
 
 模型调用会产生第三方 API 费用。部分工作流会执行模型生成的代码，请仅在可信本机环境
 运行并检查输入数据。
@@ -105,6 +107,30 @@ cd ..
 
 访问 <http://127.0.0.1:15173>。后端 API 文档位于
 <http://127.0.0.1:18000/docs>。运行 `win_stop.bat` 停止服务。
+
+### macOS 源码模式
+
+```bash
+git clone https://github.com/zhou2030109-glitch/Remit.git
+cd Remit
+
+cp backend/.env.example backend/.env.dev
+
+cd backend
+uv sync --frozen
+
+cd ../frontend
+pnpm install --frozen-lockfile
+
+cd ..
+./mac_start.command        # 或者: bash tools/start_services.sh
+```
+
+访问 <http://127.0.0.1:15173>。后端 API 文档位于
+<http://127.0.0.1:18000/docs>。运行 `bash tools/stop_services.sh`（或双击
+`mac_stop.command`）停止服务。首次运行前需要 `brew install redis`；启动脚本
+会自动生成缺失的 `backend/.env.dev`，并在 16379 端口运行 Remit 专属的 Redis
+实例。`tools/start_services.sh --check` 可以随时校验启动依赖。
 
 ### Docker Compose
 
@@ -138,7 +164,7 @@ COORDINATOR_MAX_TOKENS=8192
 
 ## 开发与验证
 
-```powershell
+```bash
 cd backend
 uv run ruff check app tests
 uv run pytest tests -q
@@ -148,7 +174,8 @@ pnpm run lint
 pnpm run build
 
 cd ..
-backend/.venv/Scripts/python.exe -m pytest tests -q
+# 仓库级启动器与配置契约测试（Windows 使用 .venv\Scripts\python.exe）
+backend/.venv/bin/python -m pytest tests -q
 ```
 
 Windows 安装包可通过以下命令生成，默认产物位于当前用户本地应用数据目录下的

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Remit 把题面理解、数据检查、文献研究、模型选择、代码执�
 
 ## 运行要求
 
-- Windows 10/11（桌面启动器）、macOS 12+（脚本启动）或支持 Docker Compose 的系统；
+- Windows 10/11（桌面启动器）、macOS 12+/Linux（脚本启动）或支持 Docker Compose 的系统；
 - Python 3.12+ 与 [uv](https://docs.astral.sh/uv/)；
 - Node.js 20+ 与 pnpm 10；
 - 完整工作流需要 Redis。Windows 源码模式可使用仓库内置的 Redis 运行文件；
-  macOS 通过 `brew install redis` 安装，启动脚本会在 16379 端口拉起一个
-  Remit 专属的 Redis 实例，不影响系统已有 Redis。
+  macOS 通过 `brew install redis` 安装，Linux 使用发行版的软件包管理器；
+  启动脚本会在 16379 端口拉起一个 Remit 专属实例，且不会接管外部 Redis。
 
 模型调用会产生第三方 API 费用。部分工作流会执行模型生成的代码，请仅在可信本机环境
 运行并检查输入数据。
@@ -108,7 +108,7 @@ cd ..
 访问 <http://127.0.0.1:15173>。后端 API 文档位于
 <http://127.0.0.1:18000/docs>。运行 `win_stop.bat` 停止服务。
 
-### macOS 源码模式
+### macOS / Linux 源码模式
 
 ```bash
 git clone https://github.com/zhou2030109-glitch/Remit.git
@@ -123,14 +123,15 @@ cd ../frontend
 pnpm install --frozen-lockfile
 
 cd ..
-./mac_start.command        # 或者: bash tools/start_services.sh
+bash tools/start_services.sh
 ```
 
 访问 <http://127.0.0.1:15173>。后端 API 文档位于
-<http://127.0.0.1:18000/docs>。运行 `bash tools/stop_services.sh`（或双击
-`mac_stop.command`）停止服务。首次运行前需要 `brew install redis`；启动脚本
-会自动生成缺失的 `backend/.env.dev`，并在 16379 端口运行 Remit 专属的 Redis
-实例。`tools/start_services.sh --check` 可以随时校验启动依赖。
+<http://127.0.0.1:18000/docs>。运行 `bash tools/stop_services.sh` 停止服务。
+macOS 也可双击 `mac_start.command` / `mac_stop.command`。首次运行前请安装 Redis
+（macOS：`brew install redis`；Linux：使用发行版的软件包管理器）和 `lsof`。
+启动脚本会自动生成缺失的 `backend/.env.dev`；
+`tools/start_services.sh --check` 可以随时校验启动依赖。
 
 ### Docker Compose
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,11 +34,13 @@ workflow details.
 
 ## Requirements
 
-- Windows 10/11 for the desktop launcher, or a Docker Compose environment;
+- Windows 10/11 for the desktop launcher, macOS 12+ via the shell launcher, or
+  a Docker Compose environment;
 - Python 3.12+ and [uv](https://docs.astral.sh/uv/);
 - Node.js 20+ and pnpm 10;
 - Redis for the complete workflow. Windows source mode can use the bundled
-  Redis runtime files.
+  Redis runtime files; on macOS install Redis with `brew install redis` — the
+  launcher starts a Remit-dedicated instance on port 16379.
 
 Provider calls may incur external API charges. Some workflows execute
 model-generated code; run Remit only on a trusted workstation and inspect your
@@ -66,6 +68,31 @@ cd ..
 
 Open <http://127.0.0.1:15173>. Backend API documentation is available at
 <http://127.0.0.1:18000/docs>. Run `win_stop.bat` to stop all services.
+
+### macOS from source
+
+```bash
+git clone https://github.com/zhou2030109-glitch/Remit.git
+cd Remit
+
+cp backend/.env.example backend/.env.dev
+
+cd backend
+uv sync --frozen
+
+cd ../frontend
+pnpm install --frozen-lockfile
+
+cd ..
+./mac_start.command        # or: bash tools/start_services.sh
+```
+
+Open <http://127.0.0.1:15173>. Backend API documentation is available at
+<http://127.0.0.1:18000/docs>. Run `bash tools/stop_services.sh` (or double-click
+`mac_stop.command`) to stop all services. Install Redis with `brew install redis`
+first; the launcher creates a missing `backend/.env.dev` automatically and runs
+a Remit-dedicated Redis instance on port 16379. `tools/start_services.sh
+--check` validates the launch dependencies at any time.
 
 ### Docker Compose
 
@@ -102,7 +129,7 @@ problem and data through the UI.
 
 ## Development
 
-```powershell
+```bash
 cd backend
 uv run ruff check app tests
 uv run pytest tests -q
@@ -112,7 +139,8 @@ pnpm run lint
 pnpm run build
 
 cd ..
-backend/.venv/Scripts/python.exe -m pytest tests -q
+# Repository-level launcher and config contract tests (Windows: .venv\Scripts\python.exe)
+backend/.venv/bin/python -m pytest tests -q
 ```
 
 To build the Windows installer, run `tools/package_win.ps1`. Its default output

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,13 +34,14 @@ workflow details.
 
 ## Requirements
 
-- Windows 10/11 for the desktop launcher, macOS 12+ via the shell launcher, or
-  a Docker Compose environment;
+- Windows 10/11 for the desktop launcher, macOS 12+ or Linux via the shell
+  launcher, or a Docker Compose environment;
 - Python 3.12+ and [uv](https://docs.astral.sh/uv/);
 - Node.js 20+ and pnpm 10;
 - Redis for the complete workflow. Windows source mode can use the bundled
-  Redis runtime files; on macOS install Redis with `brew install redis` — the
-  launcher starts a Remit-dedicated instance on port 16379.
+  Redis runtime files. On macOS use `brew install redis`; on Linux use the
+  distribution package manager. The launcher starts a dedicated instance on
+  port 16379 and never takes ownership of an external Redis process.
 
 Provider calls may incur external API charges. Some workflows execute
 model-generated code; run Remit only on a trusted workstation and inspect your
@@ -69,7 +70,7 @@ cd ..
 Open <http://127.0.0.1:15173>. Backend API documentation is available at
 <http://127.0.0.1:18000/docs>. Run `win_stop.bat` to stop all services.
 
-### macOS from source
+### macOS / Linux from source
 
 ```bash
 git clone https://github.com/zhou2030109-glitch/Remit.git
@@ -84,15 +85,16 @@ cd ../frontend
 pnpm install --frozen-lockfile
 
 cd ..
-./mac_start.command        # or: bash tools/start_services.sh
+bash tools/start_services.sh
 ```
 
 Open <http://127.0.0.1:15173>. Backend API documentation is available at
-<http://127.0.0.1:18000/docs>. Run `bash tools/stop_services.sh` (or double-click
-`mac_stop.command`) to stop all services. Install Redis with `brew install redis`
-first; the launcher creates a missing `backend/.env.dev` automatically and runs
-a Remit-dedicated Redis instance on port 16379. `tools/start_services.sh
---check` validates the launch dependencies at any time.
+<http://127.0.0.1:18000/docs>. Run `bash tools/stop_services.sh` to stop all
+services. On macOS you can instead double-click `mac_start.command` /
+`mac_stop.command`. Install Redis and `lsof` first (`brew install redis` on
+macOS; use the distribution package manager on Linux). The launcher creates a
+missing `backend/.env.dev` automatically. `tools/start_services.sh --check`
+validates the launch dependencies at any time.
 
 ### Docker Compose
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,9 +3,9 @@
 FastAPI services, agent workflow, model-provider adapters, local execution, and
 task persistence for [Remit](../README_EN.md).
 
-```powershell
+```bash
 uv sync --frozen
-Copy-Item .env.example .env.dev
+cp .env.example .env.dev          # Windows: Copy-Item .env.example .env.dev
 uv run uvicorn app.main:app --host 127.0.0.1 --port 18000
 ```
 

--- a/backend/app/tools/matlab_interpreter.py
+++ b/backend/app/tools/matlab_interpreter.py
@@ -148,7 +148,8 @@ class MatlabCodeInterpreter(BaseCodeInterpreter):
         self._write_metadata()
         logger.info(f"MATLAB 常驻计算后端可用: {self.executable} ({self.version})")
 
-    def _candidate_engine_architectures(self) -> list[str]:
+    @staticmethod
+    def _candidate_engine_architectures() -> list[str]:
         """按本机平台给出 Engine 二进制目录的候选名，原生架构优先。
 
         Intel Mac 目录名为 ``maci64``，Apple Silicon（R2023b 起）为
@@ -157,17 +158,29 @@ class MatlabCodeInterpreter(BaseCodeInterpreter):
         if os.name == "nt":
             return ["win64"]
         if sys.platform == "darwin":
-            return (
-                ["maca64", "maci64"]
-                if platform.machine() == "arm64"
-                else ["maci64", "maca64"]
-            )
+            # Python 扩展必须与当前解释器同架构；原生 arm64 进程无法加载
+            # maci64，Intel/Rosetta 进程也无法加载 maca64。
+            return ["maca64"] if platform.machine() == "arm64" else ["maci64"]
         return ["glnxa64"]
 
     @staticmethod
-    def _engine_paths_for_arch(
-        root: Path, arch: str
-    ) -> tuple[Path, Path, Path, Path]:
+    def _runtime_library_variable() -> str | None:
+        """返回当前平台供动态链接器查找 MATLAB 共享库的环境变量。"""
+        if sys.platform == "darwin":
+            return "DYLD_LIBRARY_PATH"
+        if os.name != "nt":
+            return "LD_LIBRARY_PATH"
+        return None
+
+    @staticmethod
+    def _prepend_environment_paths(name: str, paths: list[Path]) -> None:
+        """把存在的目录去重后前置到指定的路径型环境变量。"""
+        existing = [item for item in os.environ.get(name, "").split(os.pathsep) if item]
+        prefixes = [str(path) for path in paths if path.is_dir()]
+        os.environ[name] = os.pathsep.join(list(dict.fromkeys([*prefixes, *existing])))
+
+    @staticmethod
+    def _engine_paths_for_arch(root: Path, arch: str) -> tuple[Path, Path, Path, Path]:
         """返回该架构下 Engine 加载所需的四个目录。"""
         engine_dist = root / "extern" / "engines" / "python" / "dist"
         engine_bin = engine_dist / "matlab" / "engine" / arch
@@ -189,21 +202,29 @@ class MatlabCodeInterpreter(BaseCodeInterpreter):
                 break
             if missing_report is None:
                 missing_report = missing
-        if arch is None or engine_bin is None or extern_bin is None or runtime_bin is None:
+        if (
+            arch is None
+            or engine_bin is None
+            or extern_bin is None
+            or runtime_bin is None
+        ):
             raise MatlabUnavailableError(
                 "MATLAB Engine 组件不完整，缺少: " + ", ".join(missing_report or [])
             )
 
         engine_dist = root / "extern" / "engines" / "python" / "dist"
+        system_bin = root / "sys" / "os" / arch
         os.environ["MWE_INSTALL"] = str(root)
         for path in (engine_dist, engine_bin, extern_bin):
             path_text = str(path)
             if path_text not in sys.path:
                 sys.path.insert(0, path_text)
 
-        path_prefixes = [str(runtime_bin), str(extern_bin), str(engine_bin)]
-        current_path = os.environ.get("PATH", "")
-        os.environ["PATH"] = os.pathsep.join(path_prefixes + [current_path])
+        runtime_paths = [runtime_bin, extern_bin, engine_bin, system_bin]
+        self._prepend_environment_paths("PATH", runtime_paths)
+        library_variable = self._runtime_library_variable()
+        if library_variable:
+            self._prepend_environment_paths(library_variable, runtime_paths)
         if hasattr(os, "add_dll_directory"):
             for path in (runtime_bin, extern_bin, engine_bin):
                 self._dll_handles.append(os.add_dll_directory(str(path)))

--- a/backend/app/tools/matlab_interpreter.py
+++ b/backend/app/tools/matlab_interpreter.py
@@ -7,6 +7,7 @@ import importlib
 import io
 import json
 import os
+import platform
 import re
 import shutil
 import sys
@@ -66,22 +67,32 @@ class MatlabCodeInterpreter(BaseCodeInterpreter):
         if path_match:
             return str(Path(path_match).resolve())
 
-        roots = [
-            Path(os.environ.get("ProgramFiles", "C:/Program Files")) / "MATLAB",
-            Path("D:/Program Files/MATLAB"),
-        ]
+        roots: list[Path] = []
+        glob_pattern = "R*/bin/matlab"
+        if sys.platform == "darwin":
+            # macOS 官方安装包位于 /Applications/MATLAB_R20xx?.app
+            roots.append(Path("/Applications"))
+            glob_pattern = "MATLAB_R*.app/bin/matlab"
+        elif os.name == "nt":
+            roots = [
+                Path(os.environ.get("ProgramFiles", "C:/Program Files")) / "MATLAB",
+                Path("D:/Program Files/MATLAB"),
+            ]
+            glob_pattern = "R*/bin/matlab.exe"
+        else:
+            roots.append(Path("/usr/local/MATLAB"))
         candidates = [
             executable
             for root in roots
             if root.is_dir()
-            for executable in root.glob("R*/bin/matlab.exe")
+            for executable in root.glob(glob_pattern)
             if executable.is_file()
         ]
         return str(sorted(candidates, reverse=True)[0]) if candidates else None
 
     @property
     def matlab_root(self) -> Path:
-        """从 ``<MATLAB>/bin/matlab.exe`` 解析 MATLAB 根目录。"""
+        """从 ``<MATLAB>/bin/matlab``（平台可执行文件）解析 MATLAB 根目录。"""
         if not self.executable:
             raise MatlabUnavailableError("未找到 MATLAB 可执行文件")
         executable = Path(self.executable).resolve()
@@ -137,21 +148,53 @@ class MatlabCodeInterpreter(BaseCodeInterpreter):
         self._write_metadata()
         logger.info(f"MATLAB 常驻计算后端可用: {self.executable} ({self.version})")
 
-    def _load_engine_module(self) -> Any:
-        """直接加载当前 MATLAB 安装附带的 Engine，不要求全局 pip 安装。"""
-        root = self.matlab_root
-        arch = "win64" if os.name == "nt" else "glnxa64"
+    def _candidate_engine_architectures(self) -> list[str]:
+        """按本机平台给出 Engine 二进制目录的候选名，原生架构优先。
+
+        Intel Mac 目录名为 ``maci64``，Apple Silicon（R2023b 起）为
+        ``maca64``；旧版安装可能缺少其中一个，因此按序回退。
+        """
+        if os.name == "nt":
+            return ["win64"]
+        if sys.platform == "darwin":
+            return (
+                ["maca64", "maci64"]
+                if platform.machine() == "arm64"
+                else ["maci64", "maca64"]
+            )
+        return ["glnxa64"]
+
+    @staticmethod
+    def _engine_paths_for_arch(
+        root: Path, arch: str
+    ) -> tuple[Path, Path, Path, Path]:
+        """返回该架构下 Engine 加载所需的四个目录。"""
         engine_dist = root / "extern" / "engines" / "python" / "dist"
         engine_bin = engine_dist / "matlab" / "engine" / arch
         extern_bin = root / "extern" / "bin" / arch
         runtime_bin = root / "bin" / arch
-        required = (engine_dist, engine_bin, extern_bin, runtime_bin)
-        missing = [str(path) for path in required if not path.is_dir()]
-        if missing:
+        return engine_dist, engine_bin, extern_bin, runtime_bin
+
+    def _load_engine_module(self) -> Any:
+        """直接加载当前 MATLAB 安装附带的 Engine，不要求全局 pip 安装。"""
+        root = self.matlab_root
+        arch: str | None = None
+        missing_report: list[str] | None = None
+        engine_bin = extern_bin = runtime_bin = None
+        for candidate in self._candidate_engine_architectures():
+            paths = self._engine_paths_for_arch(root, candidate)
+            missing = [str(path) for path in paths if not path.is_dir()]
+            if not missing:
+                arch, engine_bin, extern_bin, runtime_bin = candidate, *paths[1:]
+                break
+            if missing_report is None:
+                missing_report = missing
+        if arch is None or engine_bin is None or extern_bin is None or runtime_bin is None:
             raise MatlabUnavailableError(
-                "MATLAB Engine 组件不完整，缺少: " + ", ".join(missing)
+                "MATLAB Engine 组件不完整，缺少: " + ", ".join(missing_report or [])
             )
 
+        engine_dist = root / "extern" / "engines" / "python" / "dist"
         os.environ["MWE_INSTALL"] = str(root)
         for path in (engine_dist, engine_bin, extern_bin):
             path_text = str(path)

--- a/backend/app/utils/paper_polish.py
+++ b/backend/app/utils/paper_polish.py
@@ -447,6 +447,10 @@ def load_font(work_dir: Path, size: int) -> ImageFont.FreeTypeFont | ImageFont.I
         backend_root / "fonts" / "SimHei.ttf",
         backend_root / "fonts" / "msyh.ttc",
         Path("C:/Windows/Fonts/simhei.ttf"),
+        Path("/System/Library/Fonts/PingFang.ttc"),
+        Path("/System/Library/Fonts/Supplemental/Songti.ttc"),
+        Path("/System/Library/Fonts/Hiragino Sans GB.ttc"),
+        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
     ]
     for candidate in candidates:
         if candidate.exists():

--- a/backend/app/utils/paper_polish.py
+++ b/backend/app/utils/paper_polish.py
@@ -447,9 +447,12 @@ def load_font(work_dir: Path, size: int) -> ImageFont.FreeTypeFont | ImageFont.I
         backend_root / "fonts" / "SimHei.ttf",
         backend_root / "fonts" / "msyh.ttc",
         Path("C:/Windows/Fonts/simhei.ttf"),
-        Path("/System/Library/Fonts/PingFang.ttc"),
-        Path("/System/Library/Fonts/Supplemental/Songti.ttc"),
+        # macOS：PingFang.ttc 受 SIP 保护无法被 PIL 读取，选用实测可打开的字体
+        Path("/System/Library/Fonts/STHeiti Medium.ttc"),
         Path("/System/Library/Fonts/Hiragino Sans GB.ttc"),
+        Path("/System/Library/Fonts/Supplemental/Songti.ttc"),
+        Path("/Library/Fonts/Arial Unicode.ttf"),
+        Path("/System/Library/Fonts/Supplemental/Arial Unicode.ttf"),
         Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
     ]
     for candidate in candidates:

--- a/backend/tests/test_desktop_launcher.py
+++ b/backend/tests/test_desktop_launcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 from urllib.parse import urlparse
@@ -20,6 +21,10 @@ def load_desktop_module():
     return module
 
 
+@unittest.skipUnless(
+    sys.platform == "win32",
+    "桌面壳使用 Win32 API（ctypes.windll/pythonnet），仅 Windows 可加载",
+)
 class DesktopLauncherTests(unittest.TestCase):
     def test_desktop_sets_explicit_windows_app_identity(self) -> None:
         """解释器承载的窗口必须有独立 AppID，否则任务栏显示 Python 图标。"""

--- a/backend/tests/test_matlab_interpreter.py
+++ b/backend/tests/test_matlab_interpreter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -30,6 +31,46 @@ class MatlabInterpreterTests(unittest.IsolatedAsyncioTestCase):
         description = tools[0]["function"]["description"]
         self.assertIn("MATLAB syntax only", description)
         self.assertIn("Do not send Python code", description)
+
+    def test_macos_engine_architecture_matches_python_process(self) -> None:
+        with (
+            patch("app.tools.matlab_interpreter.os.name", "posix"),
+            patch("app.tools.matlab_interpreter.sys.platform", "darwin"),
+            patch(
+                "app.tools.matlab_interpreter.platform.machine", return_value="arm64"
+            ),
+        ):
+            self.assertEqual(
+                MatlabCodeInterpreter._candidate_engine_architectures(),
+                ["maca64"],
+            )
+
+        with (
+            patch("app.tools.matlab_interpreter.os.name", "posix"),
+            patch("app.tools.matlab_interpreter.sys.platform", "darwin"),
+            patch(
+                "app.tools.matlab_interpreter.platform.machine", return_value="x86_64"
+            ),
+        ):
+            self.assertEqual(
+                MatlabCodeInterpreter._candidate_engine_architectures(),
+                ["maci64"],
+            )
+
+    def test_runtime_library_paths_are_prepended_without_duplicates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "bin"
+            second = Path(tmp) / "sys"
+            first.mkdir()
+            second.mkdir()
+            with patch.dict(os.environ, {"DYLD_LIBRARY_PATH": str(second)}):
+                MatlabCodeInterpreter._prepend_environment_paths(
+                    "DYLD_LIBRARY_PATH", [first, second]
+                )
+                self.assertEqual(
+                    os.environ["DYLD_LIBRARY_PATH"].split(os.pathsep),
+                    [str(first), str(second)],
+                )
 
     async def test_factory_uses_python_only_after_matlab_probe_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/backend/tests/test_prod_launcher.py
+++ b/backend/tests/test_prod_launcher.py
@@ -21,6 +21,10 @@ def load_prod_launcher():
     return module
 
 
+@unittest.skipUnless(
+    sys.platform == "win32",
+    "安装版启动器依赖 Windows 打包布局与 taskkill，仅 Windows 可加载",
+)
 class ProductionLauncherTests(unittest.TestCase):
     def test_stop_services_falls_back_to_owned_port_processes(self) -> None:
         """PID 文件丢失时也必须清理本安装目录遗留的监听进程。"""

--- a/frontend/src/components/GlobalCommandPalette.vue
+++ b/frontend/src/components/GlobalCommandPalette.vue
@@ -9,6 +9,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { displayTitle } from "@/utils/title";
 import {
 	Command,
 	FolderOpen,
@@ -167,7 +168,7 @@ onBeforeUnmount(() =>
               <FolderOpen class="h-3.5 w-3.5" aria-hidden="true" />
             </span>
             <span class="min-w-0 flex-1 text-left">
-              <span class="block truncate text-sm">{{ task.title }}</span>
+              <span class="block truncate text-sm">{{ displayTitle(task.title, 60) }}</span>
               <span class="block text-[11px] text-muted-foreground">{{ task.message_count }} 条运行记录</span>
             </span>
           </Button>

--- a/frontend/src/pages/home.vue
+++ b/frontend/src/pages/home.vue
@@ -1442,7 +1442,9 @@ a {
 	display: grid;
 	gap: 10px;
 	margin-top: 18px;
-}.review-row {
+}
+
+.review-row {
 	display: grid;
 	min-height: 72px;
 	grid-template-columns: 42px minmax(0, 1fr) auto 15px;

--- a/frontend/src/pages/home.vue
+++ b/frontend/src/pages/home.vue
@@ -17,6 +17,7 @@ import {
 import { useToast } from "@/components/ui/toast";
 import ApiDialog from "@/pages/chat/components/ApiDialog.vue";
 import { useTaskStore } from "@/stores/task";
+import { displayTitle } from "@/utils/title";
 import { isAxiosError } from "axios";
 import {
 	AlertCircle,
@@ -188,7 +189,10 @@ async function confirmTaskDeletion(): Promise<void> {
 	try {
 		await taskStore.deleteTask(task.task_id);
 		taskPendingDelete.value = null;
-		toast({ title: "项目已删除", description: `“${task.title}”已永久删除。` });
+		toast({
+			title: "项目已删除",
+			description: `“${displayTitle(task.title, 60)}”已永久删除。`,
+		});
 	} catch (error) {
 		const responseData = isAxiosError(error)
 			? (error.response?.data as { detail?: string } | undefined)
@@ -345,7 +349,7 @@ onMounted(async () => {
 					<article class="current-project-card">
 						<div class="project-copy">
 							<p>当前项目</p>
-							<h1>{{ recentTask?.title || "创建第一个建模项目" }}</h1>
+							<h1>{{ displayTitle(recentTask?.title) || "创建第一个建模项目" }}</h1>
 							<div class="project-progress">
 								<strong class="mono-data">{{ currentProgress }}%</strong>
 								<div class="progress-track" aria-hidden="true">
@@ -433,7 +437,7 @@ onMounted(async () => {
 								class="review-row"
 							>
 								<span class="review-icon"><AlertCircle aria-hidden="true" /></span>
-								<strong>{{ task.title }}</strong>
+								<strong>{{ displayTitle(task.title, 30) }}</strong>
 								<small>{{ formatTaskTime(task.updated_at) }}</small>
 								<ChevronRight aria-hidden="true" />
 							</RouterLink>
@@ -531,14 +535,14 @@ onMounted(async () => {
 								<span>{{ statusConfig[task.status].label }}</span>
 								<button
 									type="button"
-									:aria-label="`删除项目：${task.title}`"
+									:aria-label="`删除项目：${displayTitle(task.title, 60)}`"
 									@click="taskPendingDelete = task"
 								>
 									<Trash2 aria-hidden="true" />
 								</button>
 							</div>
 							<RouterLink :to="`/project/${task.task_id}/overview`">
-								<h3>{{ task.title }}</h3>
+								<h3>{{ displayTitle(task.title, 36) }}</h3>
 								<div class="recent-progress">
 									<strong class="mono-data">{{ statusConfig[task.status].progress }}%</strong>
 									<span><i :style="{ width: `${statusConfig[task.status].progress}%` }" /></span>
@@ -574,7 +578,7 @@ onMounted(async () => {
 				<DialogHeader>
 					<DialogTitle>永久删除这个项目？</DialogTitle>
 					<DialogDescription class="pt-1 leading-6">
-						<span class="block font-medium text-foreground">{{ taskPendingDelete?.title }}</span>
+						<span class="block font-medium text-foreground">{{ displayTitle(taskPendingDelete?.title, 60) }}</span>
 						<span class="mt-1 block">消息、附件和生成文件都会删除，无法撤销。</span>
 					</DialogDescription>
 				</DialogHeader>
@@ -1391,10 +1395,10 @@ a {
 }
 
 :global(.dark .soft-glass) {
-	border-color: rgb(255 255 255 / 0.06);
-	background: var(--acid);
-	box-shadow: 0 28px 64px -44px rgb(194 225 0 / 0.36);
-	color: #111;
+	border-color: rgb(231 255 47 / 0.26);
+	background: linear-gradient(160deg, #242a20, #161913);
+	box-shadow: 0 28px 64px -44px rgb(0 0 0 / 0.62);
+	color: #f2f4ec;
 	backdrop-filter: none;
 }
 
@@ -1434,17 +1438,11 @@ a {
 	font-weight: 800;
 }
 
-:global(.dark .count-mark) {
-	background: rgb(17 19 16 / 0.1);
-}
-
 .review-list {
 	display: grid;
 	gap: 10px;
 	margin-top: 18px;
-}
-
-.review-row {
+}.review-row {
 	display: grid;
 	min-height: 72px;
 	grid-template-columns: 42px minmax(0, 1fr) auto 15px;
@@ -1459,7 +1457,9 @@ a {
 }
 
 :global(.dark .review-row) {
-	background: rgb(255 255 255 / 0.82);
+	border-color: rgb(255 255 255 / 0.09);
+	background: rgb(255 255 255 / 0.05);
+	color: #eef0ea;
 }
 
 .review-icon {
@@ -1469,6 +1469,11 @@ a {
 	place-items: center;
 	border-radius: 50%;
 	background: rgb(17 19 17 / 0.055);
+}
+
+:global(.dark .review-icon) {
+	background: rgb(231 255 47 / 0.13);
+	color: var(--acid);
 }
 
 .review-icon svg {
@@ -1489,6 +1494,10 @@ a {
 	white-space: nowrap;
 }
 
+:global(.dark .review-row small) {
+	color: rgb(244 245 239 / 0.62);
+}
+
 .review-row > svg {
 	width: 14px;
 	height: 14px;
@@ -1504,13 +1513,17 @@ a {
 }
 
 :global(.dark .review-empty) {
-	color: #30342f;
+	color: rgb(244 245 239 / 0.66);
 }
 
 .review-empty svg {
 	width: 34px;
 	height: 34px;
 	color: #8ba300;
+}
+
+:global(.dark .review-empty svg) {
+	color: var(--acid);
 }
 
 .review-empty strong {
@@ -1663,8 +1676,8 @@ a {
 .agent-card {
 	position: relative;
 	overflow: hidden;
-	background: #879185;
-	color: white;
+	background: #2e342c;
+	color: #f4f5ef;
 }
 
 .agent-card::after {
@@ -1679,7 +1692,7 @@ a {
 }
 
 .agent-card > header span {
-	border: 1px solid rgb(255 255 255 / 0.2);
+	border: 1px solid rgb(255 255 255 / 0.28);
 	border-radius: 999px;
 	padding: 5px 8px;
 	font-size: 9px;
@@ -1705,18 +1718,19 @@ a {
 	grid-template-columns: 17px minmax(0, 1fr) auto;
 	align-items: center;
 	gap: 8px;
-	font-size: 10px;
+	font-size: 11px;
 }
 
 .agent-layout li svg {
 	width: 15px;
 	height: 15px;
-	opacity: 0.74;
+	color: var(--acid);
+	opacity: 0.92;
 }
 
 .agent-layout li small {
-	opacity: 0.56;
-	font-size: 8px;
+	color: rgb(244 245 239 / 0.68);
+	font-size: 9.5px;
 }
 
 .agent-visual {

--- a/frontend/src/pages/task/components/ProjectHeader.vue
+++ b/frontend/src/pages/task/components/ProjectHeader.vue
@@ -2,6 +2,7 @@
 import { Button } from "@/components/ui/button";
 import FilesSheet from "@/pages/task/components/FileSheet.vue";
 import type { ProjectStage, StageKey } from "@/pages/task/projectWorkspace";
+import { displayTitle } from "@/utils/title";
 import {
 	ArrowLeft,
 	Bot,
@@ -60,7 +61,10 @@ const statusLabel = {
 
       <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-950 text-xs font-semibold text-white dark:bg-white dark:text-slate-950">M</span>
       <div class="min-w-0 max-w-72">
-        <h1 class="truncate text-sm font-semibold" :title="props.title">{{ props.title }}</h1>
+        <h1
+          class="truncate text-sm font-semibold"
+          :title="displayTitle(props.title, 120)"
+        >{{ displayTitle(props.title, 120) }}</h1>
         <div class="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
           <span class="truncate font-mono">{{ props.taskId }}</span>
           <span class="inline-flex items-center gap-1">

--- a/frontend/src/utils/title.ts
+++ b/frontend/src/utils/title.ts
@@ -1,8 +1,8 @@
-/** 匹配行首 Markdown 记号：标题井号、引用符，以及紧跟的列表符。 */
-const LEADING_MARKDOWN_PATTERN = /^\s*(?:[#>]+\s*)+(?:[-*+]\s+)?/;
+/** 匹配行首 Markdown 块标记；要求标记后有空白，避免误伤 #1 等正文。 */
+const LEADING_MARKDOWN_PATTERN = /^\s*(?:(?:#{1,6}|>+)\s+)+(?:[-*+]\s+)?/;
 
-/** 匹配正文残留的行内 Markdown 记号：反引号与加粗、斜体星号。 */
-const INLINE_MARKDOWN_PATTERN = /[`*_]/g;
+/** 只移除成对的行内代码反引号，保留公式、文件名中的 * 与 _。 */
+const INLINE_CODE_PATTERN = /`([^`\n]+)`/g;
 
 /**
  * 把后端返回的原始 Markdown 题面清洗成单行可读标题。
@@ -20,7 +20,7 @@ export function displayTitle(
 ): string {
 	const text = (raw ?? "")
 		.replace(LEADING_MARKDOWN_PATTERN, "")
-		.replace(INLINE_MARKDOWN_PATTERN, "")
+		.replace(INLINE_CODE_PATTERN, "$1")
 		.replace(/\s+/g, " ")
 		.trim();
 	if (!text) return "";

--- a/frontend/src/utils/title.ts
+++ b/frontend/src/utils/title.ts
@@ -1,0 +1,29 @@
+/** 匹配行首 Markdown 记号：标题井号、引用符，以及紧跟的列表符。 */
+const LEADING_MARKDOWN_PATTERN = /^\s*(?:[#>]+\s*)+(?:[-*+]\s+)?/;
+
+/** 匹配正文残留的行内 Markdown 记号：反引号与加粗、斜体星号。 */
+const INLINE_MARKDOWN_PATTERN = /[`*_]/g;
+
+/**
+ * 把后端返回的原始 Markdown 题面清洗成单行可读标题。
+ *
+ * 项目标题取自题面文件首行，常带 "# "、"`segments.csv`" 这类 Markdown
+ * 记号；直接渲染会在首页横幅、项目卡片和任务顶栏露出裸记号。
+ *
+ * @param raw 后端返回的原始标题或题面首行。
+ * @param maxLen 最大字符数，超出部分以省略号截断。
+ * @returns 清洗后的单行标题；入参为空时返回空串。
+ */
+export function displayTitle(
+	raw: string | null | undefined,
+	maxLen = 42,
+): string {
+	const text = (raw ?? "")
+		.replace(LEADING_MARKDOWN_PATTERN, "")
+		.replace(INLINE_MARKDOWN_PATTERN, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (!text) return "";
+	if (text.length <= maxLen) return text;
+	return `${text.slice(0, maxLen - 1).trimEnd()}…`;
+}

--- a/mac_start.command
+++ b/mac_start.command
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Remit macOS 双击启动入口（对应 Windows 的 win_start.bat）。
+# Finder 双击本文件即可在终端中启动 Redis + FastAPI + Vue 三个服务。
+cd "$(dirname "$0")" || exit 1
+
+bash tools/start_services.sh "$@"
+code=$?
+if [ "$code" -ne 0 ]; then
+	echo ""
+	echo "[ERROR] 启动失败，请查看上方提示。"
+	read -n 1 -s -r -p "按任意键关闭窗口..."
+fi
+exit "$code"

--- a/mac_stop.command
+++ b/mac_stop.command
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Remit macOS 双击停止入口（对应 Windows 的 win_stop.bat）。
+cd "$(dirname "$0")" || exit 1
+
+bash tools/stop_services.sh
+code=$?
+if [ "$code" -ne 0 ]; then
+	echo ""
+	echo "[ERROR] 部分服务未能停止，请查看上方提示。"
+	read -n 1 -s -r -p "按任意键关闭窗口..."
+else
+	echo ""
+	echo "服务已停止，可以直接关闭本窗口。"
+fi
+exit "$code"

--- a/tests/test_posix_start_launcher.py
+++ b/tests/test_posix_start_launcher.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import shutil
+import signal
+import socket
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -13,6 +17,24 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 START_SERVICES = PROJECT_ROOT / "tools" / "start_services.sh"
 STOP_SERVICES = PROJECT_ROOT / "tools" / "stop_services.sh"
+REDIS_PORT = 16379
+
+
+def wait_for_port(port: int, *, listening: bool, timeout: float = 10) -> None:
+    """等待本机端口进入指定监听状态。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                current = True
+        except OSError:
+            current = False
+        if current is listening:
+            return
+        time.sleep(0.1)
+    raise AssertionError(
+        f"port {port} did not become " + ("ready" if listening else "free")
+    )
 
 
 @unittest.skipIf(
@@ -23,7 +45,7 @@ STOP_SERVICES = PROJECT_ROOT / "tools" / "stop_services.sh"
 class PosixStartLauncherTests(unittest.TestCase):
     def test_launcher_anchors_itself_to_project_root(self) -> None:
         text = START_SERVICES.read_text(encoding="utf-8")
-        self.assertIn('${BASH_SOURCE[0]}', text)
+        self.assertIn("${BASH_SOURCE[0]}", text)
         self.assertIn("tools/redis/redis-server", text)
         self.assertIn("/opt/homebrew/opt/redis/bin/redis-server", text)
 
@@ -45,11 +67,151 @@ class PosixStartLauncherTests(unittest.TestCase):
     def test_stop_script_only_stops_project_processes(self) -> None:
         text = STOP_SERVICES.read_text(encoding="utf-8")
         self.assertIn("lsof", text)
+        self.assertIn("is_recorded_service_process", text)
+        self.assertNotIn("topmost_project_ancestor", text)
         self.assertIn(
             "not started from this project; leaving it running",
             text,
             "stop script must warn instead of killing foreign listeners",
         )
+
+    def test_external_listener_on_redis_port_is_rejected_and_not_stopped(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            launcher = root / "tools" / "start_services.sh"
+            stopper = root / "tools" / "stop_services.sh"
+            launcher.parent.mkdir(parents=True)
+            shutil.copy2(START_SERVICES, launcher)
+            shutil.copy2(STOP_SERVICES, stopper)
+            launcher.chmod(0o755)
+            stopper.chmod(0o755)
+
+            redis_bin = root / "tools" / "redis" / "redis-server"
+            redis_bin.parent.mkdir(parents=True)
+            redis_bin.touch()
+            redis_bin.chmod(0o755)
+            backend_python = root / "backend" / ".venv" / "bin" / "python"
+            backend_python.parent.mkdir(parents=True)
+            backend_python.touch()
+            backend_python.chmod(0o755)
+            vite = root / "frontend" / "node_modules" / "vite" / "bin" / "vite.js"
+            vite.parent.mkdir(parents=True)
+            vite.touch()
+            (root / "frontend" / "package.json").write_text("{}\n", encoding="utf-8")
+
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "http.server",
+                    str(REDIS_PORT),
+                    "--bind",
+                    "127.0.0.1",
+                ],
+                # 即使外部服务恰好从仓库根目录启动，也不能仅凭 cwd 认领。
+                cwd=root,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            try:
+                wait_for_port(REDIS_PORT, listening=True)
+
+                start = subprocess.run(
+                    ["bash", str(launcher)],
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    capture_output=True,
+                    timeout=20,
+                    check=False,
+                )
+                self.assertNotEqual(start.returncode, 0, start.stdout + start.stderr)
+                self.assertIn("occupied by another application", start.stderr)
+                self.assertIsNone(
+                    process.poll(), "start launcher stopped a foreign process"
+                )
+
+                stop = subprocess.run(
+                    ["bash", str(stopper)],
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    capture_output=True,
+                    timeout=20,
+                    check=False,
+                )
+                self.assertNotEqual(stop.returncode, 0, stop.stdout + stop.stderr)
+                self.assertIn("leaving it running", stop.stdout)
+                self.assertIsNone(
+                    process.poll(), "stop launcher killed a foreign process"
+                )
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+                wait_for_port(REDIS_PORT, listening=False)
+
+    def test_backend_start_failure_returns_nonzero_without_success_banner(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            launcher = root / "tools" / "start_services.sh"
+            launcher.parent.mkdir(parents=True)
+            shutil.copy2(START_SERVICES, launcher)
+            launcher.chmod(0o755)
+
+            redis_bin = root / "tools" / "redis" / "redis-server"
+            redis_bin.parent.mkdir(parents=True)
+            redis_bin.write_text(
+                """#!/usr/bin/env bash
+port=16379
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --port) port="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+exec python3 -m http.server "$port" --bind 127.0.0.1
+""",
+                encoding="utf-8",
+            )
+            redis_bin.chmod(0o755)
+
+            backend_python = root / "backend" / ".venv" / "bin" / "python"
+            backend_python.parent.mkdir(parents=True)
+            backend_python.write_text("#!/usr/bin/env bash\nexit 7\n", encoding="utf-8")
+            backend_python.chmod(0o755)
+
+            vite = root / "frontend" / "node_modules" / "vite" / "bin" / "vite.js"
+            vite.parent.mkdir(parents=True)
+            vite.touch()
+            (root / "frontend" / "package.json").write_text("{}\n", encoding="utf-8")
+
+            try:
+                result = subprocess.run(
+                    ["bash", str(launcher)],
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    capture_output=True,
+                    timeout=20,
+                    check=False,
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("backend exited before opening port", result.stderr)
+                self.assertNotIn("Frontend: http://", result.stdout)
+            finally:
+                pid_file = root / "logs" / "redis.pid"
+                if pid_file.exists():
+                    pid = int(pid_file.read_text(encoding="utf-8").strip())
+                    try:
+                        os.kill(pid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                wait_for_port(REDIS_PORT, listening=False)
 
     def test_launcher_has_side_effect_free_dependency_check(self) -> None:
         # 从仓库外的当前目录运行，证明启动器按脚本自身位置定位项目根。

--- a/tests/test_posix_start_launcher.py
+++ b/tests/test_posix_start_launcher.py
@@ -1,0 +1,107 @@
+"""Regression tests for the POSIX (macOS/Linux) service launcher."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+START_SERVICES = PROJECT_ROOT / "tools" / "start_services.sh"
+STOP_SERVICES = PROJECT_ROOT / "tools" / "stop_services.sh"
+
+
+@unittest.skipIf(
+    sys.platform == "win32",
+    "POSIX launcher tests need bash/lsof; Windows is covered by "
+    "test_win_start_launcher.py and test_start_services_dependencies.py",
+)
+class PosixStartLauncherTests(unittest.TestCase):
+    def test_launcher_anchors_itself_to_project_root(self) -> None:
+        text = START_SERVICES.read_text(encoding="utf-8")
+        self.assertIn('${BASH_SOURCE[0]}', text)
+        self.assertIn("tools/redis/redis-server", text)
+        self.assertIn("/opt/homebrew/opt/redis/bin/redis-server", text)
+
+    def test_launcher_uses_dedicated_project_ports(self) -> None:
+        text = START_SERVICES.read_text(encoding="utf-8")
+        self.assertIn("REDIS_PORT=16379", text)
+        self.assertIn("BACKEND_PORT=18000", text)
+        self.assertIn("FRONTEND_PORT=15173", text)
+        self.assertIn("--strictPort", text)
+
+    def test_launcher_rejects_foreign_port_owners(self) -> None:
+        text = START_SERVICES.read_text(encoding="utf-8")
+        self.assertIn("occupied by another application", text)
+
+    def test_launchers_use_posix_line_endings(self) -> None:
+        for path in (START_SERVICES, STOP_SERVICES):
+            self.assertNotIn(b"\r", path.read_bytes(), f"{path.name} must stay LF")
+
+    def test_stop_script_only_stops_project_processes(self) -> None:
+        text = STOP_SERVICES.read_text(encoding="utf-8")
+        self.assertIn("lsof", text)
+        self.assertIn(
+            "not started from this project; leaving it running",
+            text,
+            "stop script must warn instead of killing foreign listeners",
+        )
+
+    def test_launcher_has_side_effect_free_dependency_check(self) -> None:
+        # 从仓库外的当前目录运行，证明启动器按脚本自身位置定位项目根。
+        with tempfile.TemporaryDirectory() as temp_directory:
+            process = subprocess.run(
+                ["bash", str(START_SERVICES), "--check"],
+                cwd=temp_directory,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                capture_output=True,
+                timeout=45,
+                check=False,
+            )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertIn("LAUNCHER_CHECK_OK", process.stdout)
+
+    def test_check_rejects_broken_vite_installation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            launcher = root / "tools" / "start_services.sh"
+            launcher.parent.mkdir(parents=True)
+            shutil.copy2(START_SERVICES, launcher)
+            launcher.chmod(0o755)
+
+            redis_bin = root / "tools" / "redis" / "redis-server"
+            redis_bin.parent.mkdir(parents=True)
+            redis_bin.touch()
+            redis_bin.chmod(0o755)
+
+            venv_bin = root / "backend" / ".venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            (venv_bin / "python").touch()
+            (venv_bin / "python").chmod(0o755)
+
+            (root / "frontend" / "node_modules").mkdir(parents=True)
+            (root / "frontend" / "package.json").touch()
+
+            process = subprocess.run(
+                ["bash", str(launcher), "--check"],
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                capture_output=True,
+                timeout=45,
+                check=False,
+            )
+
+        output = process.stdout + process.stderr
+        self.assertNotEqual(process.returncode, 0, output)
+        self.assertIn("Frontend Vite entry point not found", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_posix_start_launcher.py
+++ b/tests/test_posix_start_launcher.py
@@ -168,10 +168,13 @@ class PosixStartLauncherTests(unittest.TestCase):
             shutil.copy2(START_SERVICES, launcher)
             launcher.chmod(0o755)
 
-            redis_bin = root / "tools" / "redis" / "redis-server"
-            redis_bin.parent.mkdir(parents=True)
-            redis_bin.write_text(
-                """#!/usr/bin/env bash
+            # CI 中优先验证系统真实 Redis；仅在开发机未安装 Redis 时使用
+            # Python TCP 替身，使失败传播测试仍可独立运行。
+            if shutil.which("redis-server") is None:
+                redis_bin = root / "tools" / "redis" / "redis-server"
+                redis_bin.parent.mkdir(parents=True)
+                redis_bin.write_text(
+                    """#!/usr/bin/env bash
 port=16379
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -181,9 +184,9 @@ while [ "$#" -gt 0 ]; do
 done
 exec python3 -m http.server "$port" --bind 127.0.0.1
 """,
-                encoding="utf-8",
-            )
-            redis_bin.chmod(0o755)
+                    encoding="utf-8",
+                )
+                redis_bin.chmod(0o755)
 
             backend_python = root / "backend" / ".venv" / "bin" / "python"
             backend_python.parent.mkdir(parents=True)

--- a/tests/test_posix_start_launcher.py
+++ b/tests/test_posix_start_launcher.py
@@ -75,6 +75,11 @@ class PosixStartLauncherTests(unittest.TestCase):
             "stop script must warn instead of killing foreign listeners",
         )
 
+    def test_start_script_records_the_actual_listener_pid(self) -> None:
+        text = START_SERVICES.read_text(encoding="utf-8")
+        self.assertIn("listener_matches_started_service", text)
+        self.assertIn('printf \'%s\' "$owned_pid" >"$LOG_DIR/$name.pid"', text)
+
     def test_external_listener_on_redis_port_is_rejected_and_not_stopped(self) -> None:
         with tempfile.TemporaryDirectory() as temp_directory:
             root = Path(temp_directory)

--- a/tests/test_posix_start_launcher.py
+++ b/tests/test_posix_start_launcher.py
@@ -104,15 +104,33 @@ class PosixStartLauncherTests(unittest.TestCase):
             vite.touch()
             (root / "frontend" / "package.json").write_text("{}\n", encoding="utf-8")
 
-            process = subprocess.Popen(
+            redis_server = shutil.which("redis-server")
+            external_command = (
                 [
+                    redis_server,
+                    "--port",
+                    str(REDIS_PORT),
+                    "--bind",
+                    "127.0.0.1",
+                    "--save",
+                    "",
+                    "--appendonly",
+                    "no",
+                    "--dir",
+                    str(root),
+                ]
+                if redis_server
+                else [
                     sys.executable,
                     "-m",
                     "http.server",
                     str(REDIS_PORT),
                     "--bind",
                     "127.0.0.1",
-                ],
+                ]
+            )
+            process = subprocess.Popen(
+                external_command,
                 # 即使外部服务恰好从仓库根目录启动，也不能仅凭 cwd 认领。
                 cwd=root,
                 stdout=subprocess.DEVNULL,

--- a/tests/test_remit_port_isolation.py
+++ b/tests/test_remit_port_isolation.py
@@ -41,6 +41,21 @@ class RemitPortIsolationTests(unittest.TestCase):
         self.assertIn('"--port", "$BackendPort"', start)
         self.assertIn("--port {1} --strictPort", start)
 
+    def test_posix_launchers_use_dedicated_ports(self) -> None:
+        start = (PROJECT_ROOT / "tools" / "start_services.sh").read_text(
+            encoding="utf-8"
+        )
+        stop = (PROJECT_ROOT / "tools" / "stop_services.sh").read_text(
+            encoding="utf-8"
+        )
+
+        for script in (start, stop):
+            self.assertIn("REDIS_PORT=16379", script)
+            self.assertIn("BACKEND_PORT=18000", script)
+            self.assertIn("FRONTEND_PORT=15173", script)
+        self.assertIn("--port \"$BACKEND_PORT\"", start)
+        self.assertIn('--port "$FRONTEND_PORT" --strictPort', start)
+
     def test_local_environment_points_to_dedicated_ports(self) -> None:
         backend_env = read_dotenv(PROJECT_ROOT / "backend" / ".env.example")
         frontend_env = read_dotenv(

--- a/tests/test_start_services_dependencies.py
+++ b/tests/test_start_services_dependencies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -13,6 +14,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 START_SERVICES = PROJECT_ROOT / "tools" / "start_services.ps1"
 
 
+@unittest.skipUnless(
+    sys.platform == "win32",
+    "start_services.ps1 requires Windows venv/redis layout and powershell.exe; "
+    "POSIX environments are covered by test_posix_start_launcher.py",
+)
 class StartServicesDependencyTests(unittest.TestCase):
     def test_launcher_rejects_ports_owned_by_another_project(self) -> None:
         text = START_SERVICES.read_text(encoding="utf-8")

--- a/tests/test_win_start_launcher.py
+++ b/tests/test_win_start_launcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 
@@ -11,6 +12,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = PROJECT_ROOT / "win_start.bat"
 
 
+@unittest.skipUnless(
+    sys.platform == "win32",
+    "win_start.bat drives cmd.exe/PowerShell and only runs on Windows; "
+    "POSIX environments are covered by test_posix_start_launcher.py",
+)
 class WindowsLauncherTests(unittest.TestCase):
     def test_launcher_anchors_itself_to_project_root(self) -> None:
         text = LAUNCHER.read_text(encoding="utf-8")

--- a/tools/start_services.sh
+++ b/tools/start_services.sh
@@ -106,6 +106,10 @@ pid_ppid() {
 	ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'
 }
 
+pid_cwd() {
+	lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
+}
+
 # 判断监听进程是否属于启动器记录的服务进程树。仅凭命令名、端口或 cwd
 # 都可能误认用户自行启动的服务，因此必须以 logs/<name>.pid 为归属锚点。
 listener_belongs_to_service() {
@@ -121,6 +125,21 @@ listener_belongs_to_service() {
 		depth=$((depth + 1))
 	done
 	return 1
+}
+
+# nohup 在部分 macOS 版本上会让真正的监听进程脱离最初记录的 PID。
+# 端口启动前已经确认空闲，因此在本次启动等待期内，可用精确工作目录
+# 识别新监听进程，并把 PID 文件更新为实际监听者供后续安全停止。
+listener_matches_started_service() {
+	local name="$1" pid="$2" expected_cwd cwd
+	case "$name" in
+	redis) expected_cwd="$ROOT" ;;
+	backend) expected_cwd="$BACKEND_DIR" ;;
+	frontend) expected_cwd="$FRONTEND_DIR" ;;
+	*) return 1 ;;
+	esac
+	cwd="$(pid_cwd "$pid")"
+	[ "$cwd" = "$expected_cwd" ]
 }
 
 # $1=名称 $2=端口 $3=工作目录 其余为启动命令；端口被本项目进程占用时直接复用。
@@ -152,17 +171,20 @@ start_service() {
 }
 
 wait_for_port() {
-	local name="$1" port="$2" timeout="$3" waited=0 pid="" pids="" owned=0
+	local name="$1" port="$2" timeout="$3" waited=0 pid="" pids="" owned=0 owned_pid=""
 	while [ "$waited" -lt "$timeout" ]; do
 		pids="$(port_pids "$port" || true)"
 		if [ -n "$pids" ]; then
 			owned=0
+			owned_pid=""
 			for pid in $pids; do
-				if listener_belongs_to_service "$name" "$pid"; then
+				if listener_belongs_to_service "$name" "$pid" || listener_matches_started_service "$name" "$pid"; then
 					owned=1
+					owned_pid="$pid"
 				fi
 			done
 			if [ "$owned" = "1" ]; then
+				printf '%s' "$owned_pid" >"$LOG_DIR/$name.pid"
 				echo "[READY] $name is accepting connections on port $port."
 				return 0
 			fi

--- a/tools/start_services.sh
+++ b/tools/start_services.sh
@@ -71,6 +71,9 @@ REDIS_BIN="$(find_redis_executable || true)"
 PNPM_BIN="$(command -v pnpm 2>/dev/null || true)"
 
 assert_dependencies() {
+	if ! command -v lsof >/dev/null 2>&1; then
+		die "未找到 lsof。macOS 请安装 Xcode Command Line Tools；Linux 请安装 lsof。"
+	fi
 	if [ -z "$REDIS_BIN" ]; then
 		die "未找到可用的 redis-server。请先安装 Redis: brew install redis（或把可执行文件放到 tools/redis/redis-server）"
 	fi
@@ -103,56 +106,36 @@ pid_ppid() {
 	ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'
 }
 
-# 进程工作目录（lsof -Fn 输出形如 n/Users/.../Remit/frontend）。
-pid_cwd() {
-	lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
-}
-
-# 命令行或工作目录落在仓库内即视为项目进程，用于端口归属判定。
-# pnpm 等包装进程的命令行指向全局安装位置，只能靠 cwd 识别。
-is_project_process() {
-	local pid="$1" depth=0 cmd parent cwd
-	while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$depth" -lt 8 ]; do
-		cmd="$(pid_command "$pid")"
-		[ -n "$cmd" ] || return 1
-		case "$cmd" in
-		*"$ROOT"*) return 0 ;;
-		esac
-		cwd="$(pid_cwd "$pid")"
-		case "$cwd" in
-		"$ROOT" | "$ROOT"/*) return 0 ;;
-		esac
+# 判断监听进程是否属于启动器记录的服务进程树。仅凭命令名、端口或 cwd
+# 都可能误认用户自行启动的服务，因此必须以 logs/<name>.pid 为归属锚点。
+listener_belongs_to_service() {
+	local name="$1" pid="$2" owner parent depth=0
+	[ -f "$LOG_DIR/$name.pid" ] || return 1
+	owner="$(tr -d '[:space:]' <"$LOG_DIR/$name.pid")"
+	[ -n "$owner" ] && [ -n "$(pid_command "$owner")" ] || return 1
+	while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$depth" -lt 16 ]; do
+		[ "$pid" = "$owner" ] && return 0
 		parent="$(pid_ppid "$pid")"
-		if [ -z "$parent" ] || [ "$parent" = "$pid" ]; then
-			return 1
-		fi
+		[ -n "$parent" ] && [ "$parent" != "$pid" ] || return 1
 		pid="$parent"
 		depth=$((depth + 1))
 	done
 	return 1
 }
 
-# 启动器自己拉起的 redis（HOME 装在 PATH 下，命令行不含仓库路径）也算项目所有。
-is_redis_process() {
-	pid_command "$1" | grep -q "redis-server"
-}
-
 # $1=名称 $2=端口 $3=工作目录 其余为启动命令；端口被本项目进程占用时直接复用。
 start_service() {
 	local name="$1" port="$2" workdir="$3"
 	shift 3
-	local pids pid owned=0 redis_ok=0
+	local pids pid owned=0
 	pids="$(port_pids "$port" || true)"
 	if [ -n "$pids" ]; then
 		for pid in $pids; do
-			if is_project_process "$pid"; then
+			if listener_belongs_to_service "$name" "$pid"; then
 				owned=1
 			fi
-			if [ "$name" = "redis" ] && is_redis_process "$pid"; then
-				redis_ok=1
-			fi
 		done
-		if [ "$owned" = "1" ] || [ "$redis_ok" = "1" ]; then
+		if [ "$owned" = "1" ]; then
 			echo "[OK] $name is already listening on port $port."
 			return 0
 		fi
@@ -169,11 +152,29 @@ start_service() {
 }
 
 wait_for_port() {
-	local name="$1" port="$2" timeout="$3" waited=0
+	local name="$1" port="$2" timeout="$3" waited=0 pid="" pids="" owned=0
 	while [ "$waited" -lt "$timeout" ]; do
-		if [ -n "$(port_pids "$port")" ]; then
-			echo "[READY] $name is accepting connections on port $port."
-			return 0
+		pids="$(port_pids "$port" || true)"
+		if [ -n "$pids" ]; then
+			owned=0
+			for pid in $pids; do
+				if listener_belongs_to_service "$name" "$pid"; then
+					owned=1
+				fi
+			done
+			if [ "$owned" = "1" ]; then
+				echo "[READY] $name is accepting connections on port $port."
+				return 0
+			fi
+			echo "[ERROR] Port $port was claimed by another application while $name was starting." >&2
+			return 1
+		fi
+		if [ -f "$LOG_DIR/$name.pid" ]; then
+			pid="$(tr -d '[:space:]' <"$LOG_DIR/$name.pid")"
+			if [ -n "$pid" ] && ! ps -p "$pid" >/dev/null 2>&1; then
+				echo "[ERROR] $name exited before opening port $port; see logs/$name.err.log" >&2
+				return 1
+			fi
 		fi
 		sleep 1
 		waited=$((waited + 1))
@@ -204,16 +205,22 @@ echo "=============================================="
 
 start_service redis "$REDIS_PORT" "$ROOT" \
 	"$REDIS_BIN" --port "$REDIS_PORT" --bind 127.0.0.1 ::1 --dir "$LOG_DIR/redis-data"
-wait_for_port redis "$REDIS_PORT" 30
+if ! wait_for_port redis "$REDIS_PORT" 30; then
+	die "Redis 启动失败。可执行 bash tools/stop_services.sh 清理已启动的服务。"
+fi
 
 start_service backend "$BACKEND_PORT" "$BACKEND_DIR" \
 	"$BACKEND_PYTHON" -m uvicorn app.main:app --host 127.0.0.1 --port "$BACKEND_PORT" \
 	--ws-ping-interval 60 --ws-ping-timeout 120
-wait_for_port backend "$BACKEND_PORT" 90
+if ! wait_for_port backend "$BACKEND_PORT" 90; then
+	die "后端启动失败。可执行 bash tools/stop_services.sh 清理已启动的服务。"
+fi
 
 start_service frontend "$FRONTEND_PORT" "$FRONTEND_DIR" \
 	"$PNPM_BIN" run dev --host 127.0.0.1 --port "$FRONTEND_PORT" --strictPort
-wait_for_port frontend "$FRONTEND_PORT" 60
+if ! wait_for_port frontend "$FRONTEND_PORT" 60; then
+	die "前端启动失败。可执行 bash tools/stop_services.sh 清理已启动的服务。"
+fi
 
 echo ""
 echo "Frontend: http://localhost:$FRONTEND_PORT"

--- a/tools/start_services.sh
+++ b/tools/start_services.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Remit POSIX 服务启动器（macOS / Linux）：Redis + FastAPI + Vue。
+#
+# 用法:
+#   tools/start_services.sh            后台启动三个服务，日志写入 logs/
+#   tools/start_services.sh --check    只校验启动依赖，不启动任何服务
+#
+# 与 tools/start_services.ps1 保持同一端口契约:
+#   Redis 16379 / Backend 18000 / Frontend 15173
+#
+# Redis 不随仓库捆绑（Windows 专用目录 tools/redis 仅含 exe），POSIX 环境按
+# 仓库内置可执行文件 → PATH → Homebrew 的顺序发现本机 redis-server。
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT/backend"
+FRONTEND_DIR="$ROOT/frontend"
+LOG_DIR="$ROOT/logs"
+
+REDIS_PORT=16379
+BACKEND_PORT=18000
+FRONTEND_PORT=15173
+
+CHECK_ONLY=0
+for arg in "$@"; do
+	case "$arg" in
+	--check | -Check)
+		CHECK_ONLY=1
+		;;
+	-h | --help)
+		echo "用法: tools/start_services.sh [--check]"
+		exit 0
+		;;
+	*)
+		echo "[ERROR] 未知参数: $arg" >&2
+		exit 1
+		;;
+	esac
+done
+
+die() {
+	echo "[ERROR] $*" >&2
+	exit 1
+}
+
+find_redis_executable() {
+	local candidate
+	for candidate in \
+		"$ROOT/tools/redis/redis-server" \
+		"$(command -v redis-server 2>/dev/null || true)" \
+		/opt/homebrew/opt/redis/bin/redis-server \
+		/usr/local/opt/redis/bin/redis-server \
+		/opt/homebrew/bin/redis-server \
+		/usr/local/bin/redis-server; do
+		if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+			printf '%s' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# 后端必须以 backend/ 为工作目录启动：项目内多处使用相对路径 project/work_dir。
+BACKEND_PYTHON="$BACKEND_DIR/.venv/bin/python"
+if [ ! -x "$BACKEND_PYTHON" ]; then
+	BACKEND_PYTHON="$BACKEND_DIR/venv/bin/python"
+fi
+
+REDIS_BIN="$(find_redis_executable || true)"
+PNPM_BIN="$(command -v pnpm 2>/dev/null || true)"
+
+assert_dependencies() {
+	if [ -z "$REDIS_BIN" ]; then
+		die "未找到可用的 redis-server。请先安装 Redis: brew install redis（或把可执行文件放到 tools/redis/redis-server）"
+	fi
+	if [ ! -x "$BACKEND_PYTHON" ]; then
+		die "后端虚拟环境不存在。请先执行: cd backend && uv sync --frozen"
+	fi
+	if [ ! -f "$FRONTEND_DIR/package.json" ]; then
+		die "前端 package.json 不存在: $FRONTEND_DIR"
+	fi
+	if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
+		die "前端依赖缺失。请先执行: cd frontend && pnpm install"
+	fi
+	if [ ! -f "$FRONTEND_DIR/node_modules/vite/bin/vite.js" ]; then
+		die "Frontend Vite entry point not found. The project may have moved. Run: cd frontend; pnpm install --force --frozen-lockfile"
+	fi
+	if [ -z "$PNPM_BIN" ]; then
+		die "未找到 pnpm。请先安装: corepack enable 或 npm install -g pnpm@10"
+	fi
+}
+
+port_pids() {
+	lsof -nP -t -iTCP:"$1" -sTCP:LISTEN 2>/dev/null | sort -u
+}
+
+pid_command() {
+	ps -p "$1" -o command= 2>/dev/null | head -n 1
+}
+
+pid_ppid() {
+	ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'
+}
+
+# 进程工作目录（lsof -Fn 输出形如 n/Users/.../Remit/frontend）。
+pid_cwd() {
+	lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
+}
+
+# 命令行或工作目录落在仓库内即视为项目进程，用于端口归属判定。
+# pnpm 等包装进程的命令行指向全局安装位置，只能靠 cwd 识别。
+is_project_process() {
+	local pid="$1" depth=0 cmd parent cwd
+	while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$depth" -lt 8 ]; do
+		cmd="$(pid_command "$pid")"
+		[ -n "$cmd" ] || return 1
+		case "$cmd" in
+		*"$ROOT"*) return 0 ;;
+		esac
+		cwd="$(pid_cwd "$pid")"
+		case "$cwd" in
+		"$ROOT" | "$ROOT"/*) return 0 ;;
+		esac
+		parent="$(pid_ppid "$pid")"
+		if [ -z "$parent" ] || [ "$parent" = "$pid" ]; then
+			return 1
+		fi
+		pid="$parent"
+		depth=$((depth + 1))
+	done
+	return 1
+}
+
+# 启动器自己拉起的 redis（HOME 装在 PATH 下，命令行不含仓库路径）也算项目所有。
+is_redis_process() {
+	pid_command "$1" | grep -q "redis-server"
+}
+
+# $1=名称 $2=端口 $3=工作目录 其余为启动命令；端口被本项目进程占用时直接复用。
+start_service() {
+	local name="$1" port="$2" workdir="$3"
+	shift 3
+	local pids pid owned=0 redis_ok=0
+	pids="$(port_pids "$port" || true)"
+	if [ -n "$pids" ]; then
+		for pid in $pids; do
+			if is_project_process "$pid"; then
+				owned=1
+			fi
+			if [ "$name" = "redis" ] && is_redis_process "$pid"; then
+				redis_ok=1
+			fi
+		done
+		if [ "$owned" = "1" ] || [ "$redis_ok" = "1" ]; then
+			echo "[OK] $name is already listening on port $port."
+			return 0
+		fi
+		die "Port $port is occupied by another application. Stop that application before starting Remit."
+	fi
+
+	(
+		cd "$workdir" || exit 1
+		exec nohup "$@" >"$LOG_DIR/$name.out.log" 2>"$LOG_DIR/$name.err.log" </dev/null
+	) &
+	local service_pid=$!
+	printf '%s' "$service_pid" >"$LOG_DIR/$name.pid"
+	echo "[STARTED] $name (PID $service_pid, port $port)"
+}
+
+wait_for_port() {
+	local name="$1" port="$2" timeout="$3" waited=0
+	while [ "$waited" -lt "$timeout" ]; do
+		if [ -n "$(port_pids "$port")" ]; then
+			echo "[READY] $name is accepting connections on port $port."
+			return 0
+		fi
+		sleep 1
+		waited=$((waited + 1))
+	done
+	echo "[WARN] $name 未在 ${timeout}s 内开始监听端口 $port，请查看 logs/$name.err.log"
+	return 1
+}
+
+assert_dependencies
+
+if [ "$CHECK_ONLY" = "1" ]; then
+	echo "LAUNCHER_CHECK_OK"
+	exit 0
+fi
+
+# 没有本地配置时先从模板生成，避免裸跑落到 Docker 专用默认值 redis://redis:6379。
+if [ ! -f "$BACKEND_DIR/.env.dev" ] && [ -f "$BACKEND_DIR/.env.example" ]; then
+	cp "$BACKEND_DIR/.env.example" "$BACKEND_DIR/.env.dev"
+	echo "[INIT] 已从 .env.example 生成 backend/.env.dev，请按需填写模型 API Key。"
+fi
+
+mkdir -p "$LOG_DIR" "$LOG_DIR/redis-data"
+
+echo "=============================================="
+echo " Remit: Redis + FastAPI + Vue (macOS/Linux)"
+echo " Mode: hidden background services"
+echo "=============================================="
+
+start_service redis "$REDIS_PORT" "$ROOT" \
+	"$REDIS_BIN" --port "$REDIS_PORT" --bind 127.0.0.1 ::1 --dir "$LOG_DIR/redis-data"
+wait_for_port redis "$REDIS_PORT" 30
+
+start_service backend "$BACKEND_PORT" "$BACKEND_DIR" \
+	"$BACKEND_PYTHON" -m uvicorn app.main:app --host 127.0.0.1 --port "$BACKEND_PORT" \
+	--ws-ping-interval 60 --ws-ping-timeout 120
+wait_for_port backend "$BACKEND_PORT" 90
+
+start_service frontend "$FRONTEND_PORT" "$FRONTEND_DIR" \
+	"$PNPM_BIN" run dev --host 127.0.0.1 --port "$FRONTEND_PORT" --strictPort
+wait_for_port frontend "$FRONTEND_PORT" 60
+
+echo ""
+echo "Frontend: http://localhost:$FRONTEND_PORT"
+echo "Backend:  http://localhost:$BACKEND_PORT"
+echo "Logs:     $LOG_DIR"
+echo "Stop:     bash tools/stop_services.sh（或双击 mac_stop.command）"

--- a/tools/stop_services.sh
+++ b/tools/stop_services.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Remit POSIX 服务停止器（macOS / Linux）。与 tools/stop_services.ps1 保持
+# 相同语义：优先按 logs/<name>.pid 记录停止；PID 文件缺失时按端口发现监听
+# 进程，并只停止属于本项目的进程链，外部进程仅告警不误杀。
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$ROOT/logs"
+
+REDIS_PORT=16379
+BACKEND_PORT=18000
+FRONTEND_PORT=15173
+
+# macOS 自带 BSD tail 用 -r 反转行序，GNU coreutils 环境回退到 tac。
+if tail -r </dev/null >/dev/null 2>&1; then
+	REVERSER="tail -r"
+else
+	REVERSER="tac"
+fi
+
+port_pids() {
+	lsof -nP -t -iTCP:"$1" -sTCP:LISTEN 2>/dev/null | sort -u
+}
+
+pid_command() {
+	ps -p "$1" -o command= 2>/dev/null | head -n 1
+}
+
+pid_ppid() {
+	ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'
+}
+
+pid_alive() {
+	ps -p "$1" >/dev/null 2>&1
+}
+
+# 进程工作目录（lsof -Fn 输出形如 n/Users/.../Remit/frontend）。
+pid_cwd() {
+	lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
+}
+
+# 命令行或工作目录落在仓库内即视为项目进程。pnpm 等包装进程的命令行
+# 指向全局安装位置（如 /usr/local/bin/pnpm），只能靠 cwd 识别。
+is_project_process() {
+	local pid="$1" depth=0 cmd parent cwd
+	while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$depth" -lt 8 ]; do
+		cmd="$(pid_command "$pid")"
+		[ -n "$cmd" ] || return 1
+		case "$cmd" in
+		*"$ROOT"*) return 0 ;;
+		esac
+		cwd="$(pid_cwd "$pid")"
+		case "$cwd" in
+		"$ROOT" | "$ROOT"/*) return 0 ;;
+		esac
+		parent="$(pid_ppid "$pid")"
+		if [ -z "$parent" ] || [ "$parent" = "$pid" ]; then
+			return 1
+		fi
+		pid="$parent"
+		depth=$((depth + 1))
+	done
+	return 1
+}
+
+is_redis_process() {
+	pid_command "$1" | grep -q "redis-server"
+}
+
+# 输出该 PID 及其全部后代（父在前），供自底向上终止。
+collect_tree() {
+	local pid="$1" child
+	echo "$pid"
+	for child in $(pgrep -P "$pid" 2>/dev/null); do
+		collect_tree "$child"
+	done
+}
+
+# $1=PID $2=服务名: 先整组 TERM，宽限 5 秒后对残留进程 KILL。
+kill_tree() {
+	local pid="$1" name="$2" list p
+	list="$(collect_tree "$pid" | $REVERSER)"
+	[ -n "$list" ] || return 0
+	for p in $list; do
+		kill -TERM "$p" 2>/dev/null || true
+	done
+	local waited=0
+	while [ "$waited" -lt 50 ]; do
+		pid_alive "$pid" || break
+		sleep 0.1
+		waited=$((waited + 1))
+	done
+	for p in $list; do
+		kill -KILL "$p" 2>/dev/null || true
+	done
+	echo "[STOPPED] $name (PID $pid)"
+}
+
+# 沿父链找到最上层属于本项目的祖先，从那里整棵终止，避免遗留包装进程。
+topmost_project_ancestor() {
+	local pid="$1" parent cmd
+	while :; do
+		parent="$(pid_ppid "$pid")"
+		if [ -z "$parent" ] || [ "$parent" = "0" ] || [ "$parent" = "1" ] || [ "$parent" = "$pid" ]; then
+			break
+		fi
+		cmd="$(pid_command "$parent")"
+		[ -n "$cmd" ] || break
+		case "$cmd" in
+		*"$ROOT"*) pid="$parent" ;;
+		*) break ;;
+		esac
+	done
+	echo "$pid"
+}
+
+service_port() {
+	case "$1" in
+	frontend) echo "$FRONTEND_PORT" ;;
+	backend) echo "$BACKEND_PORT" ;;
+	redis) echo "$REDIS_PORT" ;;
+	esac
+}
+
+for service in frontend backend redis; do
+	port="$(service_port "$service")"
+	pid_file="$LOG_DIR/$service.pid"
+
+	if [ -f "$pid_file" ]; then
+		pid="$(tr -d '[:space:]' <"$pid_file")"
+		rm -f "$pid_file"
+		if [ -z "$pid" ] || ! pid_alive "$pid"; then
+			echo "[OK] $service is already stopped."
+			continue
+		fi
+		# PID 可能已被系统回收复用：确认仍属于本项目才按 PID 终止；
+		# 无法确认时继续落到按端口发现，避免误杀也避免漏杀。
+		cmd="$(pid_command "$pid")"
+		if [ "$service" = "redis" ] && is_redis_process "$pid"; then
+			kill_tree "$pid" "$service"
+			continue
+		elif [ -n "$cmd" ] && is_project_process "$pid"; then
+			kill_tree "$pid" "$service"
+			continue
+		fi
+	fi
+
+	pids="$(port_pids "$port" || true)"
+	if [ -z "$pids" ]; then
+		echo "[OK] $service is already stopped."
+		continue
+	fi
+
+	stopped=0
+	foreign=0
+	for pid in $pids; do
+		if [ "$service" = "redis" ] && is_redis_process "$pid"; then
+			:
+		elif ! is_project_process "$pid"; then
+			foreign=1
+			continue
+		fi
+		top="$(topmost_project_ancestor "$pid")"
+		kill_tree "$top" "$service"
+		stopped=1
+	done
+
+	if [ "$stopped" = "0" ]; then
+		echo "[WARN] $service uses port $port, but it was not started from this project; leaving it running."
+	fi
+done

--- a/tools/stop_services.sh
+++ b/tools/stop_services.sh
@@ -12,6 +12,11 @@ REDIS_PORT=16379
 BACKEND_PORT=18000
 FRONTEND_PORT=15173
 
+if ! command -v lsof >/dev/null 2>&1; then
+	echo "[ERROR] 未找到 lsof，无法安全判断端口进程归属。" >&2
+	exit 1
+fi
+
 # macOS 自带 BSD tail 用 -r 反转行序，GNU coreutils 环境回退到 tac。
 if tail -r </dev/null >/dev/null 2>&1; then
 	REVERSER="tail -r"
@@ -27,10 +32,6 @@ pid_command() {
 	ps -p "$1" -o command= 2>/dev/null | head -n 1
 }
 
-pid_ppid() {
-	ps -p "$1" -o ppid= 2>/dev/null | tr -d '[:space:]'
-}
-
 pid_alive() {
 	ps -p "$1" >/dev/null 2>&1
 }
@@ -40,32 +41,26 @@ pid_cwd() {
 	lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
 }
 
-# 命令行或工作目录落在仓库内即视为项目进程。pnpm 等包装进程的命令行
-# 指向全局安装位置（如 /usr/local/bin/pnpm），只能靠 cwd 识别。
-is_project_process() {
-	local pid="$1" depth=0 cmd parent cwd
-	while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$depth" -lt 8 ]; do
-		cmd="$(pid_command "$pid")"
-		[ -n "$cmd" ] || return 1
-		case "$cmd" in
-		*"$ROOT"*) return 0 ;;
-		esac
-		cwd="$(pid_cwd "$pid")"
-		case "$cwd" in
-		"$ROOT" | "$ROOT"/*) return 0 ;;
-		esac
-		parent="$(pid_ppid "$pid")"
-		if [ -z "$parent" ] || [ "$parent" = "$pid" ]; then
-			return 1
-		fi
-		pid="$parent"
-		depth=$((depth + 1))
-	done
-	return 1
-}
-
-is_redis_process() {
-	pid_command "$1" | grep -q "redis-server"
+is_recorded_service_process() {
+	local service="$1" pid="$2" cwd cmd expected_cwd
+	cwd="$(pid_cwd "$pid")"
+	cmd="$(pid_command "$pid")"
+	case "$service" in
+	redis)
+		expected_cwd="$ROOT"
+		case "$cmd" in *redis-server*) ;; *) return 1 ;; esac
+		;;
+	backend)
+		expected_cwd="$ROOT/backend"
+		case "$cmd" in *uvicorn*app.main:app*) ;; *) return 1 ;; esac
+		;;
+	frontend)
+		expected_cwd="$ROOT/frontend"
+		case "$cmd" in *pnpm*run*dev* | *vite*15173*) ;; *) return 1 ;; esac
+		;;
+	*) return 1 ;;
+	esac
+	[ "$cwd" = "$expected_cwd" ]
 }
 
 # 输出该 PID 及其全部后代（父在前），供自底向上终止。
@@ -97,24 +92,6 @@ kill_tree() {
 	echo "[STOPPED] $name (PID $pid)"
 }
 
-# 沿父链找到最上层属于本项目的祖先，从那里整棵终止，避免遗留包装进程。
-topmost_project_ancestor() {
-	local pid="$1" parent cmd
-	while :; do
-		parent="$(pid_ppid "$pid")"
-		if [ -z "$parent" ] || [ "$parent" = "0" ] || [ "$parent" = "1" ] || [ "$parent" = "$pid" ]; then
-			break
-		fi
-		cmd="$(pid_command "$parent")"
-		[ -n "$cmd" ] || break
-		case "$cmd" in
-		*"$ROOT"*) pid="$parent" ;;
-		*) break ;;
-		esac
-	done
-	echo "$pid"
-}
-
 service_port() {
 	case "$1" in
 	frontend) echo "$FRONTEND_PORT" ;;
@@ -122,6 +99,8 @@ service_port() {
 	redis) echo "$REDIS_PORT" ;;
 	esac
 }
+
+overall_status=0
 
 for service in frontend backend redis; do
 	port="$(service_port "$service")"
@@ -137,10 +116,7 @@ for service in frontend backend redis; do
 		# PID 可能已被系统回收复用：确认仍属于本项目才按 PID 终止；
 		# 无法确认时继续落到按端口发现，避免误杀也避免漏杀。
 		cmd="$(pid_command "$pid")"
-		if [ "$service" = "redis" ] && is_redis_process "$pid"; then
-			kill_tree "$pid" "$service"
-			continue
-		elif [ -n "$cmd" ] && is_project_process "$pid"; then
+		if [ -n "$cmd" ] && is_recorded_service_process "$service" "$pid"; then
 			kill_tree "$pid" "$service"
 			continue
 		fi
@@ -152,21 +128,10 @@ for service in frontend backend redis; do
 		continue
 	fi
 
-	stopped=0
-	foreign=0
-	for pid in $pids; do
-		if [ "$service" = "redis" ] && is_redis_process "$pid"; then
-			:
-		elif ! is_project_process "$pid"; then
-			foreign=1
-			continue
-		fi
-		top="$(topmost_project_ancestor "$pid")"
-		kill_tree "$top" "$service"
-		stopped=1
-	done
-
-	if [ "$stopped" = "0" ]; then
-		echo "[WARN] $service uses port $port, but it was not started from this project; leaving it running."
-	fi
+	# 没有可信 PID 记录时绝不按端口或 cwd 猜测归属。宁可提示用户手动
+	# 处理残留，也不能误停恰好使用同一端口、命令或目录的外部进程。
+	echo "[WARN] $service uses port $port, but it was not started from this project; leaving it running."
+	overall_status=1
 done
+
+exit "$overall_status"


### PR DESCRIPTION
## 概要
- 引入 xingranya 的 macOS/Linux 原生启动支持与界面改进，并保留原作者记录
- 收紧 POSIX 服务归属判断，防止误停外部 Redis/用户进程
- 启动失败时正确返回非零状态，不再输出成功提示
- 修复 MATLAB Engine 跨平台动态库路径和标题字符清洗
- 补充 POSIX 启动器及 MATLAB 回归测试，更新中英文运行文档

## 取舍
未引入 fork 中与功能无关、包含未确认陈述的 `PRODUCT.md`。

## 本地验证
- Backend: 194 passed
- Repository/Windows launchers: 23 passed, 9 skipped
- Frontend: lint + production build passed
- WSL/Linux live safety regressions: 2 passed