### PR TITLE
docs: refresh cached community QR image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ Remit 面向可信的单用户本机环境，不具备公网多租户服务所�
 **Remit（数模 Agent）**。欢迎分享建议、问题和实际使用体验。
 
 <p align="center">
-  <a href="./assets/remit-wechat-group.png">
-    <img src="./assets/remit-wechat-group.png" alt="Remit 数模 Agent 微信交流群二维码，2026 年 9 月 14 日前有效" width="360" />
+  <a href="./assets/remit-wechat-group.png?v=20260907">
+    <img src="./assets/remit-wechat-group.png?v=20260907" alt="Remit 数模 Agent 微信交流群二维码，2026 年 9 月 14 日前有效" width="360" />
   </a>
 </p>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -192,8 +192,8 @@ Scan the QR code to join the **Remit (数模 Agent)** WeChat group for usage
 questions, mathematical modeling workflows, feedback, and development discussion.
 
 <p align="center">
-  <a href="./assets/remit-wechat-group.png">
-    <img src="./assets/remit-wechat-group.png" alt="Remit WeChat group QR code, valid before September 14, 2026" width="360" />
+  <a href="./assets/remit-wechat-group.png?v=20260907">
+    <img src="./assets/remit-wechat-group.png?v=20260907" alt="Remit WeChat group QR code, valid before September 14, 2026" width="360" />
   </a>
 </p>
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -473,8 +473,8 @@ docker compose up --build
 想法，都欢迎进群讨论。
 
 <p align="center">
-  <a href="../assets/remit-wechat-group.png">
-    <img src="../assets/remit-wechat-group.png" alt="Remit 数模 Agent 微信交流群二维码，2026 年 9 月 14 日前有效" width="360" />
+  <a href="../assets/remit-wechat-group.png?v=20260907">
+    <img src="../assets/remit-wechat-group.png?v=20260907" alt="Remit 数模 Agent 微信交流群二维码，2026 年 9 月 14 日前有效" width="360" />
   </a>
 </p>
 


### PR DESCRIPTION
Add a date version to the WeChat QR image and full-resolution links in both READMEs and the workflow guide so cached images refresh after the September 7 replacement.

Validation: git diff --check passed. The replacement PNG exactly matches the user-supplied file (1260 × 1859). No runtime code changed.