### PR TITLE
feat: make first-run setup work from a clean checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ Remit 是一个本地优先的开源数学建模 AI 助手（数模 Agent），�
 git clone https://github.com/zhou2030109-glitch/Remit.git
 cd Remit
 
-Copy-Item backend/.env.example backend/.env.dev
-
 cd backend
 uv sync --frozen
 
@@ -109,14 +107,13 @@ cd ..
 
 访问 <http://127.0.0.1:15173>。后端 API 文档位于
 <http://127.0.0.1:18000/docs>。运行 `win_stop.bat` 停止服务。
+首次启动会自动生成 `backend/.env.dev`；模型密钥可在界面中填写，也可稍后编辑该文件。
 
 ### macOS / Linux 源码模式
 
 ```bash
 git clone https://github.com/zhou2030109-glitch/Remit.git
 cd Remit
-
-cp backend/.env.example backend/.env.dev
 
 cd backend
 uv sync --frozen
@@ -138,11 +135,10 @@ macOS 也可双击 `mac_start.command` / `mac_stop.command`。首次运行前请
 ### Docker Compose
 
 ```bash
-cp backend/.env.example backend/.env.dev
 docker compose up --build
 ```
 
-前端默认端口为 `15173`，后端为 `18000`，Redis 为 `16379`。
+前端默认端口为 `15173`，后端为 `18000`，Redis 为 `16379`。首次启动无需预先创建 `backend/.env.dev`；模型密钥可在界面中填写，也可按需创建该文件。
 
 需要可直接运行的生产镜像或离线安装包时，见[发布包构建与使用](docs/distribution.md)。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -61,8 +61,6 @@ inputs.
 git clone https://github.com/zhou2030109-glitch/Remit.git
 cd Remit
 
-Copy-Item backend/.env.example backend/.env.dev
-
 cd backend
 uv sync --frozen
 
@@ -75,14 +73,13 @@ cd ..
 
 Open <http://127.0.0.1:15173>. Backend API documentation is available at
 <http://127.0.0.1:18000/docs>. Run `win_stop.bat` to stop all services.
+The first launch creates `backend/.env.dev` automatically; provider keys can be entered in the UI or added to that file later.
 
 ### macOS / Linux from source
 
 ```bash
 git clone https://github.com/zhou2030109-glitch/Remit.git
 cd Remit
-
-cp backend/.env.example backend/.env.dev
 
 cd backend
 uv sync --frozen
@@ -105,12 +102,12 @@ validates the launch dependencies at any time.
 ### Docker Compose
 
 ```bash
-cp backend/.env.example backend/.env.dev
 docker compose up --build
 ```
 
 The default ports are `15173` for the frontend, `18000` for the backend, and
-`16379` for Redis.
+`16379` for Redis. `backend/.env.dev` is optional for a first launch; provider
+keys can be entered in the UI or added to that file later.
 
 ## Model configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
     ports:
       - "18000:8000"
     env_file:
-      - ./backend/.env.dev
+      - path: ./backend/.env.dev
+        required: false
     environment:
       ENV: DEV
       REDIS_URL: redis://redis:6379/0

--- a/tests/test_posix_start_launcher.py
+++ b/tests/test_posix_start_launcher.py
@@ -56,6 +56,11 @@ class PosixStartLauncherTests(unittest.TestCase):
         self.assertIn("FRONTEND_PORT=15173", text)
         self.assertIn("--strictPort", text)
 
+    def test_launcher_requires_node_24_and_pnpm_10(self) -> None:
+        text = START_SERVICES.read_text(encoding="utf-8")
+        self.assertIn("Node.js 24", text)
+        self.assertIn("pnpm 10", text)
+
     def test_launcher_rejects_foreign_port_owners(self) -> None:
         text = START_SERVICES.read_text(encoding="utf-8")
         self.assertIn("occupied by another application", text)

--- a/tests/test_start_services_dependencies.py
+++ b/tests/test_start_services_dependencies.py
@@ -25,6 +25,19 @@ class StartServicesDependencyTests(unittest.TestCase):
         self.assertIn("Test-ProjectOwnedListener", text)
         self.assertIn("occupied by another application", text)
 
+    def test_launcher_generates_missing_dev_env_after_dependency_check(self) -> None:
+        text = START_SERVICES.read_text(encoding="utf-8")
+        call = "\nInitialize-BackendEnvironment\nNew-Item"
+        self.assertIn("function Initialize-BackendEnvironment", text)
+        self.assertIn("Copy-Item -LiteralPath $examplePath -Destination $envPath", text)
+        self.assertIn(call, text)
+        self.assertLess(text.index("if ($Check)"), text.index(call))
+
+    def test_launcher_requires_node_24_and_pnpm_10(self) -> None:
+        text = START_SERVICES.read_text(encoding="utf-8")
+        self.assertIn("Node.js 24 is required", text)
+        self.assertIn("pnpm 10 is required", text)
+
     def test_check_rejects_broken_vite_installation(self) -> None:
         with tempfile.TemporaryDirectory() as temp_directory:
             root = Path(temp_directory)

--- a/tools/start_services.ps1
+++ b/tools/start_services.ps1
@@ -36,7 +36,25 @@ function Assert-LauncherDependencies {
     if (-not (Test-Path -LiteralPath $viteEntryPoint -PathType Leaf)) {
         throw "Frontend Vite entry point not found. The project may have moved. Run: cd frontend; pnpm install --force --frozen-lockfile"
     }
-    $script:PnpmCommand = (Get-Command "pnpm.cmd" -ErrorAction Stop).Source
+
+    $nodeCommand = Get-Command "node.exe" -ErrorAction SilentlyContinue
+    if ($null -eq $nodeCommand) {
+        throw "Node.js 24 is required but node.exe was not found. Install Node.js 24 and reopen the launcher."
+    }
+    $nodeVersion = (& $nodeCommand.Source --version).Trim()
+    if ($nodeVersion -notmatch '^v24\.') {
+        throw "Node.js 24 is required (found $nodeVersion). Install Node.js 24 and reopen the launcher."
+    }
+
+    $pnpmCommand = Get-Command "pnpm.cmd" -ErrorAction SilentlyContinue
+    if ($null -eq $pnpmCommand) {
+        throw "pnpm 10 is required but pnpm.cmd was not found. Run: corepack enable (or npm install -g pnpm@10.6.3)"
+    }
+    $pnpmVersion = (& $pnpmCommand.Source --version).Trim()
+    if ($pnpmVersion -notmatch '^10\.') {
+        throw "pnpm 10 is required (found $pnpmVersion). Run: corepack prepare pnpm@10.6.3 --activate"
+    }
+    $script:PnpmCommand = $pnpmCommand.Source
 }
 
 function Test-ListeningPort([int]$Port) {
@@ -78,6 +96,16 @@ function Save-ServicePid([string]$Name, [System.Diagnostics.Process]$Process) {
     }
     $identity | ConvertTo-Json | Set-Content -LiteralPath "$pidPath.json" -Encoding UTF8
     Set-Content -LiteralPath $pidPath -Value $Process.Id -Encoding ascii -NoNewline
+}
+
+function Initialize-BackendEnvironment {
+    $envPath = Join-Path $BackendDirectory ".env.dev"
+    $examplePath = Join-Path $BackendDirectory ".env.example"
+    if (-not (Test-Path -LiteralPath $envPath -PathType Leaf) -and
+        (Test-Path -LiteralPath $examplePath -PathType Leaf)) {
+        Copy-Item -LiteralPath $examplePath -Destination $envPath
+        Write-Host "[INIT] Generated backend\.env.dev from .env.example. Add provider API keys when needed."
+    }
 }
 
 function Start-ProjectService {
@@ -123,6 +151,7 @@ if ($Check) {
     exit 0
 }
 
+Initialize-BackendEnvironment
 New-Item -ItemType Directory -Path $LogDirectory -Force | Out-Null
 $ListeningPorts = @(
     [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties().GetActiveTcpListeners() |

--- a/tools/start_services.sh
+++ b/tools/start_services.sh
@@ -68,6 +68,7 @@ if [ ! -x "$BACKEND_PYTHON" ]; then
 fi
 
 REDIS_BIN="$(find_redis_executable || true)"
+NODE_BIN="$(command -v node 2>/dev/null || true)"
 PNPM_BIN="$(command -v pnpm 2>/dev/null || true)"
 
 assert_dependencies() {
@@ -89,9 +90,22 @@ assert_dependencies() {
 	if [ ! -f "$FRONTEND_DIR/node_modules/vite/bin/vite.js" ]; then
 		die "Frontend Vite entry point not found. The project may have moved. Run: cd frontend; pnpm install --force --frozen-lockfile"
 	fi
-	if [ -z "$PNPM_BIN" ]; then
-		die "未找到 pnpm。请先安装: corepack enable 或 npm install -g pnpm@10"
+	if [ -z "$NODE_BIN" ]; then
+		die "未找到 Node.js。请安装 Node.js 24（见 frontend/.node-version）后重试。"
 	fi
+	node_version="$($NODE_BIN --version 2>/dev/null || true)"
+	case "$node_version" in
+	v24.*) ;;
+	*) die "需要 Node.js 24（当前: ${node_version:-未知}）。请按 frontend/.node-version 安装。" ;;
+	esac
+	if [ -z "$PNPM_BIN" ]; then
+		die "未找到 pnpm。请先安装: corepack enable 或 npm install -g pnpm@10.6.3"
+	fi
+	pnpm_version="$($PNPM_BIN --version 2>/dev/null || true)"
+	case "$pnpm_version" in
+	10.*) ;;
+	*) die "需要 pnpm 10（当前: ${pnpm_version:-未知}）。请执行: corepack prepare pnpm@10.6.3 --activate" ;;
+	esac
 }
 
 port_pids() {


### PR DESCRIPTION
## Summary

This PR makes the source and Docker setup work from a clean checkout without a manual environment-file step.

A new user should be able to clone the repository, install the documented prerequisites, and start the application. Previously, both source launchers failed when `backend/.env.dev` was missing, even though the repository already shipped a safe template at `backend/.env.example`.

## What changed

### Source launchers

- Generate `backend/.env.dev` from `backend/.env.example` when it is missing.
- Never overwrite an existing `.env.dev`, so user configuration is preserved.
- Apply the same behavior to the Windows and POSIX launchers.
- Validate Node 24 and pnpm 10 before starting the frontend.
- Return actionable messages when a required version is missing or incompatible.

### Docker Compose

- Mark `backend/.env.dev` as optional in Compose.
- Allow `docker compose up --build` to work from a clean clone without copying the environment template first.
- Keep existing `.env.dev` values active when the file is present.

### Documentation and tests

- Remove the manual environment-file copy step from `README.md` and `README_EN.md`.
- Add regression coverage for the generated environment file and launcher dependency checks.

## Compatibility

- Existing `.env.dev` files are never modified or replaced.
- Existing Docker users with an environment file continue to use it unchanged.
- The Compose change uses the optional `env_file` form supported by current Docker Compose releases.
- No backend API or workflow protocol changes are introduced.

## Verification

- Repository test suite: `34 passed, 11 skipped`.
- Windows launcher dependency check: `LAUNCHER_CHECK_OK`.
- Compose configuration validates successfully when `backend/.env.dev` is absent.
- The launchers still report clear errors for unsupported Node or pnpm versions.

## Notes for maintainers

- The generated environment file contains only the public template values. API keys still need to be supplied by the user when a provider-backed workflow is used.
- This PR is intentionally limited to first-run setup and does not include the broader CI or release changes.
