### PR TITLE
fix: make workflow runtime guards explicit

### DIFF
--- a/backend/app/core/agents/coder_agent.py
+++ b/backend/app/core/agents/coder_agent.py
@@ -173,7 +173,8 @@ class CoderAgent(Agent):
     # ---- 步骤拆分 ----
 
     def _require_interpreter(self) -> BaseCodeInterpreter:
-        assert self.code_interpreter is not None, "code_interpreter 未初始化"
+        if self.code_interpreter is None:
+            raise RuntimeError("code_interpreter is not initialized")
         return self.code_interpreter
 
     async def _prime_history(self, prompt: str) -> None:

--- a/backend/app/core/workflow.py
+++ b/backend/app/core/workflow.py
@@ -358,7 +358,8 @@ class RemitWorkFlow(WorkFlow):
         ) and "pilot" not in state.get("completed_nodes", [])
         if pending_solution_keys or pilot_pending:
             await self._initialize_interpreter(state)
-            assert self.code_interpreter is not None
+            if self.code_interpreter is None:
+                raise RuntimeError("code interpreter is not initialized")
             coder_agent = self._new_coder_agent(coder_llm, problem)
             # EDA 先行：探索实验依赖清洗后的数据
             if "eda" in solution_flows and "solve:eda" not in state.get(
@@ -447,7 +448,8 @@ class RemitWorkFlow(WorkFlow):
 
     async def _publish_progress(self, state: dict[str, Any]) -> None:
         """推送实时进度快照；失败只记日志，不阻断工作流。"""
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         try:
             message = build_progress_message(self.task_id, self.checkpoint, state)
             await redis_manager.publish_message(self.task_id, message)
@@ -455,18 +457,21 @@ class RemitWorkFlow(WorkFlow):
             logger.warning(f"进度推送失败: {exc}")
 
     async def _start_node(self, state: dict[str, Any], node_id: str) -> None:
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         self.checkpoint.start_node(state, node_id)
         await self._publish_progress(state)
 
     async def _complete_node(self, state: dict[str, Any], node_id: str) -> None:
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         self.checkpoint.complete_node(state, node_id)
         await self._publish_progress(state)
 
     def _next_step_plain(self, state: dict[str, Any], node_id: str) -> str:
         """给审批卡计算"批准后会发生什么"的大白话描述。"""
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         order = self.checkpoint.node_order(state)
         try:
             index = order.index(node_id)
@@ -489,7 +494,8 @@ class RemitWorkFlow(WorkFlow):
         explain: dict[str, Any] | None = None,
     ) -> None:
         """按 HIL 配置建立人工闸门；自动模式绝不放行不完整产物。"""
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         checkpoint_key = self._hil_checkpoint_key(node_id)
         if not self._hil_enabled_for(node_id):
             if allow_incomplete:
@@ -534,7 +540,8 @@ class RemitWorkFlow(WorkFlow):
         self, state: dict[str, Any]
     ) -> dict[str, Any]:
         """让关闭 HIL 后恢复的旧任务不再困在历史审核状态。"""
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         pending = self.checkpoint.pending_approval(state)
         if not pending:
             return state
@@ -571,7 +578,8 @@ class RemitWorkFlow(WorkFlow):
             self.ques_count = response.ques_count
             return response
 
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         await self._start_node(state, "coordinator")
         opening_notice = SystemMessage(content="正在梳理题意并建立问题结构…")
         await redis_manager.publish_message(self.task_id, opening_notice)
@@ -627,7 +635,8 @@ class RemitWorkFlow(WorkFlow):
         if "modeler" in state.get("completed_nodes", []) and saved:
             return ModelerToCoder.model_validate(saved)
 
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         await self._start_node(state, "modeler")
         await redis_manager.publish_message(
             self.task_id,
@@ -866,13 +875,15 @@ class RemitWorkFlow(WorkFlow):
             refined = CoordinatorToModeler.model_validate(saved)
             if "analysis" in state.get("approved_nodes", []):
                 return refined
-            assert self.checkpoint is not None
+            if self.checkpoint is None:
+                raise RuntimeError("workflow checkpoint is not initialized")
             pending = self.checkpoint.pending_approval(state)
             if pending and pending.get("node_id") == "analysis":
                 raise WorkflowApprovalRequired(pending)
             await self._submit_analysis_approval(state, refined)
 
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         await self._start_node(state, "analysis")
         await self._check_cancelled()
         cumulative_feedback = self.checkpoint.cumulative_revision_feedback(
@@ -976,7 +987,8 @@ class RemitWorkFlow(WorkFlow):
         scholar: OpenAlexScholar,
     ) -> CoordinatorToModeler:
         """数据侦察 + 文献调研；信息性节点，失败降级，不设审批暂停。"""
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         if "research" not in self.checkpoint.node_order(state):
             # 旧任务没有该节点，保持原行为
             return coordinator_response
@@ -1079,8 +1091,10 @@ class RemitWorkFlow(WorkFlow):
         成功后把定案方案写回 state["modeler_response"]；开启审核时暂停，
         自动模式由 execute 立即加载新方案。降级跳过时沿用原方案。
         """
-        assert self.checkpoint is not None
-        assert self.code_interpreter is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
+        if self.code_interpreter is None:
+            raise RuntimeError("code interpreter is not initialized")
         node_id = "pilot"
         await self._start_node(state, node_id)
         await self._check_cancelled()
@@ -1145,7 +1159,8 @@ class RemitWorkFlow(WorkFlow):
                         + build_pilot_coder_prompt(plan)
                         + feedback_suffix
                     )
-            assert results is not None
+            if results is None:
+                raise RuntimeError("workflow results are not initialized")
 
             await publish_activity(
                 self.task_id, "建模手正在基于小实验数据定案…", category="llm"
@@ -1286,7 +1301,8 @@ class RemitWorkFlow(WorkFlow):
             timeout=int(settings.MATLAB_EXECUTION_TIMEOUT_SECONDS),
             preferred_backend=preferred_backend,
         )
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         state["execution_backend"] = {
             "language": self.code_interpreter.language,
             "name": self.code_interpreter.backend_name,
@@ -1313,8 +1329,10 @@ class RemitWorkFlow(WorkFlow):
         user_output: UserOutput,
     ) -> None:
         """执行一个求解节点，并在代码与写作门禁都通过后提交检查点。"""
-        assert self.checkpoint is not None
-        assert self.code_interpreter is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
+        if self.code_interpreter is None:
+            raise RuntimeError("code interpreter is not initialized")
         node_id = f"solve:{key}"
         await self._start_node(state, node_id)
         await self._check_cancelled()
@@ -1443,7 +1461,8 @@ class RemitWorkFlow(WorkFlow):
                         ),
                     )
         for gate_attempt in range(1, 4):
-            assert contract is not None, f"{key} 缺少强制质量契约"
+            if contract is None:
+                raise RuntimeError(f"{key} 缺少强制质量契约")
             if gate_attempt == 1 and recovered_gate_report is not None:
                 coder_response = CoderToWriter(
                     code_response=(
@@ -1688,7 +1707,10 @@ class RemitWorkFlow(WorkFlow):
 
             if execution_review.verdict == "refine":
                 revision_plan = execution_review.revision_plan
-                assert revision_plan is not None
+                if revision_plan is None:
+                    raise RuntimeError(
+                        "execution review did not provide a revision plan"
+                    )
                 revision_history.append(
                     {
                         "attempt": gate_attempt,
@@ -1728,9 +1750,12 @@ class RemitWorkFlow(WorkFlow):
             self.checkpoint.save(state)
             break
 
-        assert coder_response is not None
-        assert gate_report is not None
-        assert execution_review is not None
+        if coder_response is None:
+            raise RuntimeError("coder response is not available")
+        if gate_report is None:
+            raise RuntimeError("quality gate report is not available")
+        if execution_review is None:
+            raise RuntimeError("execution review is not available")
         await redis_manager.publish_message(
             self.task_id,
             SystemMessage(
@@ -1842,7 +1867,8 @@ class RemitWorkFlow(WorkFlow):
                     + writer_prompt
                 )
 
-        assert writer_response is not None
+        if writer_response is None:
+            raise RuntimeError("writer response is not available")
         user_output.set_res(key, writer_response)
         state.setdefault("solution_results", {})[key] = {
             "coder_response": coder_response.model_dump(mode="json"),
@@ -1960,7 +1986,8 @@ class RemitWorkFlow(WorkFlow):
 
     def _new_coder_agent(self, coder_llm: LLM, problem: Problem) -> CoderAgent:
         """Bind the active interpreter to one solver session."""
-        assert self.code_interpreter is not None
+        if self.code_interpreter is None:
+            raise RuntimeError("code interpreter is not initialized")
         return CoderAgent(
             problem.task_id,
             coder_llm,
@@ -1987,7 +2014,8 @@ class RemitWorkFlow(WorkFlow):
         各章节输入互不引用（flows 六章 prompt 相互独立），并行不损失一致性；
         合并审批仍保留退回单章的能力（revision_targets 含全部章节）。
         """
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         await self._start_node(state, f"write:{pending_write[0][0]}")
         await self._check_cancelled()
         await redis_manager.publish_message(
@@ -2145,7 +2173,8 @@ class RemitWorkFlow(WorkFlow):
         judge_llm: LLM,
     ) -> dict[str, Any] | None:
         """终稿评委评审 + 最弱章节定向重写；失败降级，绝不阻塞交付。"""
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         existing = state.get("paper_review")
         if isinstance(existing, dict) and existing:
             # 哨兵值表示上次评审已降级跳过：一次 finalize 生命周期内不重试
@@ -2311,7 +2340,8 @@ class RemitWorkFlow(WorkFlow):
         judge_llm: LLM,
     ) -> None:
         """合并全文并执行最终硬门禁。"""
-        assert self.checkpoint is not None
+        if self.checkpoint is None:
+            raise RuntimeError("workflow checkpoint is not initialized")
         await self._start_node(state, "finalize")
         await self._check_cancelled()
         revision_feedback = self.checkpoint.consume_revision_feedback(state, "finalize")

--- a/backend/app/tools/e2b_interpreter.py
+++ b/backend/app/tools/e2b_interpreter.py
@@ -108,7 +108,8 @@ class E2BCodeInterpreter(BaseCodeInterpreter):
 
     async def _upload_all_files(self) -> None:
         """把任务目录里可上传的文件推到沙箱 home。"""
-        assert self.sbx is not None
+        if self.sbx is None:
+            raise RuntimeError("E2B sandbox is not initialized")
         if not os.path.isdir(self.work_dir):
             raise FileNotFoundError(f"工作目录不存在: {self.work_dir}")
         for name in os.listdir(self.work_dir):
@@ -252,7 +253,8 @@ class E2BCodeInterpreter(BaseCodeInterpreter):
 
     async def download_all_files_from_sandbox(self) -> None:
         """把沙箱 home 下的文件全量同步回本地任务目录。"""
-        assert self.sbx is not None
+        if self.sbx is None:
+            raise RuntimeError("E2B sandbox is not initialized")
         os.makedirs(self.work_dir, exist_ok=True)
         try:
             entries = await self.sbx.files.list(_SANDBOX_HOME)

--- a/backend/app/tools/local_interpreter.py
+++ b/backend/app/tools/local_interpreter.py
@@ -250,7 +250,8 @@ class LocalCodeInterpreter(BaseCodeInterpreter):
 
     def _run_raw(self, code: str) -> list[tuple[str, str]]:
         """把代码发给内核，收割 iopub 消息并归类为 ``(标记, 内容)``。"""
-        assert self.kc is not None and self.km is not None
+        if self.kc is None or self.km is None:
+            raise RuntimeError("Jupyter kernel client is not initialized")
         kc, km = self.kc, self.km
         kc.execute(code)
         collected: list[tuple[str, str]] = []

--- a/backend/tests/test_coder_agent_resilience.py
+++ b/backend/tests/test_coder_agent_resilience.py
@@ -74,6 +74,13 @@ class CoderAgentResilienceTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertGreater(with_code, small + 500)
 
+    def test_missing_interpreter_raises_explicit_runtime_error(self) -> None:
+        agent = _make_agent()
+        agent.code_interpreter = None
+
+        with self.assertRaisesRegex(RuntimeError, "not initialized"):
+            agent._require_interpreter()
+
     async def test_transport_failure_is_not_returned_as_completed_code(self) -> None:
         agent = _make_agent(max_retries=2)
         agent._chat = AsyncMock(side_effect=ConnectionError("provider offline"))

--- a/backend/tests/test_workflow_runtime_guards.py
+++ b/backend/tests/test_workflow_runtime_guards.py
@@ -1,0 +1,19 @@
+"""Runtime state guards must not disappear under optimized Python."""
+
+from __future__ import annotations
+
+import unittest
+
+from app.core.workflow import RemitWorkFlow
+
+
+class WorkflowRuntimeGuardTests(unittest.IsolatedAsyncioTestCase):
+    async def test_start_node_requires_checkpoint(self) -> None:
+        workflow = RemitWorkFlow()
+
+        with self.assertRaisesRegex(RuntimeError, "checkpoint is not initialized"):
+            await workflow._start_node({}, "coordinator")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR replaces critical Python `assert` statements with explicit runtime guards in workflow and execution paths.

Assertions are not a reliable way to protect runtime invariants because Python removes them when the interpreter runs with `-O` or `-OO`. In the affected paths, an optimized run could continue with an uninitialized checkpoint, interpreter, or agent dependency and fail later with a less useful `NoneType` error.

## What changed

- Replace workflow checkpoint assertions with explicit `RuntimeError` checks.
- Apply the same explicit guard to `CoderAgent` interpreter initialization.
- Apply explicit guards to the E2B and local Jupyter interpreter paths.
- Add regression tests for the workflow and coder-agent guard behavior.

## Why this matters

The previous assertions protected important state transitions, but they were effectively optional under optimized Python. The new checks preserve the invariant regardless of interpreter flags and produce a direct error message at the point where the invalid state is detected.

## Compatibility

- Valid workflow and execution paths are unchanged.
- Invalid internal state now raises `RuntimeError` instead of `AssertionError`.
- No public API, data format, or workflow protocol changes are introduced.

## Verification

- Runtime-guard regression tests pass.
- Full backend suite passes: `286 passed, 1 skipped, 1 deselected`.
- The deselected case is an optional PDF test that requires a local SimHei font; it is unrelated to this change.

## Notes for maintainers

- This PR is deliberately small and focused on runtime correctness.
- The new tests exercise the failure mode directly rather than only checking the happy path.
