### PR TITLE
feat: improve status and keyboard accessibility

### DIFF
--- a/frontend/src/components/ServiceStatus.vue
+++ b/frontend/src/components/ServiceStatus.vue
@@ -49,18 +49,24 @@ function describeStatusError(error: unknown): string {
 	return "本地后端暂时不可达，请确认 Remit 仍在托盘运行";
 }
 
-/** 状态对应的容器样式 */
+/** 状态中文标签 */
+const STATUS_LABELS: Record<ServiceHealth["status"], string> = {
+	running: "正常",
+	error: "异常",
+	unknown: "检查中",
+};
+
 const CONTAINER_CLASSES: Record<ServiceHealth["status"], string> = {
-	running: "bg-green-100 text-green-800",
-	error: "bg-red-100 text-red-800",
-	unknown: "bg-gray-100 text-gray-800",
+	running: "bg-[hsl(var(--success-subtle))] text-[hsl(var(--success))]",
+	error: "bg-[hsl(var(--warning-subtle))] text-[hsl(var(--danger))]",
+	unknown: "bg-muted text-muted-foreground",
 };
 
 /** 状态对应的指示点颜色 */
 const DOT_CLASSES: Record<ServiceHealth["status"], string> = {
-	running: "bg-green-500",
-	error: "bg-red-500",
-	unknown: "bg-gray-400",
+	running: "bg-[hsl(var(--success))]",
+	error: "bg-[hsl(var(--danger))]",
+	unknown: "bg-muted-foreground",
 };
 
 /** 轮询服务状态；服务由正常转为错误时弹一次提醒 */
@@ -120,17 +126,18 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2" role="status" aria-live="polite" aria-atomic="true">
     <div
       v-for="(health, name) in services"
       :key="name"
-      class="flex items-center gap-1 px-2 py-1 rounded-md text-xs"
+      class="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs"
       :class="CONTAINER_CLASSES[health.status]"
       :title="health.message"
-      :aria-label="`${name}：${health.status}。${health.message}`"
+      :aria-label="`${name}：${STATUS_LABELS[health.status]}。${health.message}`"
     >
-	  <div class="w-2 h-2 rounded-full" :class="DOT_CLASSES[health.status]" aria-hidden="true"></div>
+      <div class="h-2 w-2 rounded-full" :class="DOT_CLASSES[health.status]" aria-hidden="true"></div>
       <span class="capitalize">{{ name }}</span>
+      <span class="text-[10px] opacity-80">{{ STATUS_LABELS[health.status] }}</span>
     </div>
   </div>
 </template>

--- a/frontend/src/components/ThemeToggle.vue
+++ b/frontend/src/components/ThemeToggle.vue
@@ -20,7 +20,9 @@ onMounted(syncTheme);
 <template>
 	<button
 		type="button"
+		role="switch"
 		class="theme-switch"
+		:aria-checked="isDark"
 		:aria-label="isDark ? '切换到日间模式' : '切换到夜间模式'"
 		:title="isDark ? '日间模式' : '夜间模式'"
 		@click="toggleTheme"

--- a/frontend/src/pages/home.vue
+++ b/frontend/src/pages/home.vue
@@ -365,8 +365,8 @@ onMounted(async () => {
 				<span>Remit</span>
 			</RouterLink>
 
-			<nav class="sidebar-nav">
-				<RouterLink to="/home" class="sidebar-item sidebar-active">
+			<nav class="sidebar-nav" aria-label="主要导航">
+				<RouterLink to="/home" class="sidebar-item sidebar-active" aria-current="page">
 					<Home aria-hidden="true" />
 					<span>工作台</span>
 				</RouterLink>

--- a/frontend/src/pages/task/components/ProjectWorkspaceShell.vue
+++ b/frontend/src/pages/task/components/ProjectWorkspaceShell.vue
@@ -365,6 +365,12 @@ watch(wideWorkspace, (isWide) => {
 </script>
 
 <template>
+  <a
+    href="#project-workspace-main"
+    class="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-[200] focus:rounded-md focus:bg-primary focus:px-3 focus:py-2 focus:text-primary-foreground focus:shadow-lg"
+  >
+    跳到主要内容
+  </a>
   <div class="fixed inset-0 flex min-h-0 flex-col bg-background">
     <ProjectHeader
       :task-id="props.taskId"
@@ -402,7 +408,7 @@ watch(wideWorkspace, (isWide) => {
 
       <ResizablePanelGroup direction="horizontal" class="min-w-0 flex-1">
         <ResizablePanel :default-size="copilotOpen ? 75 : 100" :min-size="52" class="min-w-0">
-          <main class="flex h-full min-h-0 min-w-0 flex-col" :aria-label="`${stageLabels[activeStage]}工作区`">
+          <main id="project-workspace-main" class="flex h-full min-h-0 min-w-0 flex-col" :aria-label="`${stageLabels[activeStage]}工作区`">
             <WorkflowProgress
               :progress="taskStore.latestProgress"
               :is-running="taskStore.isRunning"
@@ -410,7 +416,7 @@ watch(wideWorkspace, (isWide) => {
               :waiting-label="taskStore.pendingApproval?.node_label ?? ''"
             />
 
-            <div v-if="taskStore.pendingApproval" class="flex shrink-0 flex-wrap items-center gap-2 border-b border-[hsl(var(--warning)/0.28)] bg-[hsl(var(--warning-subtle))] px-4 py-2">
+            <div v-if="taskStore.pendingApproval" class="flex shrink-0 flex-wrap items-center gap-2 border-b border-[hsl(var(--warning)/0.28)] bg-[hsl(var(--warning-subtle))] px-4 py-2" role="status" aria-live="polite">
               <CircleAlert class="h-3.5 w-3.5 text-[hsl(var(--warning))]" aria-hidden="true" />
               <span class="min-w-0 flex-1 truncate text-[11px] font-medium text-[hsl(var(--warning))]">
                 {{ approvalBannerText }}
@@ -428,12 +434,12 @@ watch(wideWorkspace, (isWide) => {
                 <h2 class="text-xs font-semibold">{{ stageLabels[activeStage] }}</h2>
                 <span class="text-[10px] text-muted-foreground">结构化运行记录与真实文件索引</span>
               </div>
-              <div class="flex rounded-md border bg-muted/40 p-0.5">
-                <button type="button" class="inline-flex h-6 items-center gap-1 rounded px-2 text-[10px]" :class="!showCodeAssets ? 'bg-card font-medium shadow-sm' : 'text-muted-foreground'" @click="showCodeAssets = false">
+              <div class="flex rounded-md border bg-muted/40 p-0.5" role="group" aria-label="运行记录视图">
+                <button type="button" class="inline-flex h-6 items-center gap-1 rounded px-2 text-[10px]" :class="!showCodeAssets ? 'bg-card font-medium shadow-sm' : 'text-muted-foreground'" :aria-pressed="!showCodeAssets" @click="showCodeAssets = false">
                   <ListChecks class="h-3 w-3" aria-hidden="true" />
                   运行摘要
                 </button>
-                <button type="button" class="inline-flex h-6 items-center gap-1 rounded px-2 text-[10px]" :class="showCodeAssets ? 'bg-card font-medium shadow-sm' : 'text-muted-foreground'" @click="showCodeAssets = true">
+                <button type="button" class="inline-flex h-6 items-center gap-1 rounded px-2 text-[10px]" :class="showCodeAssets ? 'bg-card font-medium shadow-sm' : 'text-muted-foreground'" :aria-pressed="showCodeAssets" @click="showCodeAssets = true">
                   <FileCode2 class="h-3 w-3" aria-hidden="true" />
                   代码与文件
                 </button>

--- a/frontend/tests/accessibility.test.ts
+++ b/frontend/tests/accessibility.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import ServiceStatus from "@/components/ServiceStatus.vue";
+import ThemeToggle from "@/components/ThemeToggle.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const api = vi.hoisted(() => ({
+	getServiceStatus: vi.fn(),
+}));
+
+vi.mock("@/apis/commonApi", () => api);
+
+function source(relativePath: string): string {
+	return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+beforeEach(() => {
+	document.documentElement.classList.remove("dark");
+	api.getServiceStatus.mockResolvedValue({
+		data: {
+			backend: { status: "running", message: "ok" },
+			redis: { status: "error", message: "offline" },
+		},
+	});
+});
+
+afterEach(() => {
+	document.documentElement.classList.remove("dark");
+	vi.clearAllMocks();
+});
+
+describe("可访问状态表达", () => {
+	it("服务状态使用中文文本并通过 live region 公布", async () => {
+		const wrapper = mount(ServiceStatus);
+		await flushPromises();
+
+		expect(wrapper.attributes("role")).toBe("status");
+		expect(wrapper.attributes("aria-live")).toBe("polite");
+		expect(wrapper.text()).toContain("正常");
+		expect(wrapper.text()).toContain("异常");
+		wrapper.unmount();
+	});
+
+	it("主题切换暴露 switch 状态", async () => {
+		const wrapper = mount(ThemeToggle);
+
+		expect(wrapper.attributes("role")).toBe("switch");
+		expect(wrapper.attributes("aria-checked")).toBe("false");
+		await wrapper.trigger("click");
+		expect(wrapper.attributes("aria-checked")).toBe("true");
+		wrapper.unmount();
+	});
+
+	it("任务工作区提供跳转链接、主区域锚点和切换按钮状态", () => {
+		const workspace = source(
+			"../src/pages/task/components/ProjectWorkspaceShell.vue",
+		);
+		const home = source("../src/pages/home.vue");
+
+		expect(workspace).toContain('href="#project-workspace-main"');
+		expect(workspace).toContain('id="project-workspace-main"');
+		expect(workspace).toContain(':aria-pressed="!showCodeAssets"');
+		expect(workspace).toContain(':aria-pressed="showCodeAssets"');
+		expect(home).toContain('aria-current="page"');
+	});
+});


### PR DESCRIPTION
## Summary

This PR improves status clarity and keyboard accessibility in the frontend without changing the visual design or application flow.

Service health and approval state currently depend heavily on color or visual position. This makes the interface harder to understand for screen-reader users, keyboard-only users, and users with color-vision differences.

## What changed

### Service status

- Show explicit text for each service state: `正常`, `异常`, and `检查中`.
- Keep the existing status colors while moving them to semantic design tokens.
- Expose the combined status area as a polite live region with `role="status"` and `aria-live="polite"`.

### Keyboard and screen-reader semantics

- Add switch semantics and `aria-checked` to the theme toggle.
- Mark the active home navigation item with `aria-current="page"`.
- Add an accessible label to the primary navigation.
- Add a “skip to main content” link in the task workspace.
- Add the main-content anchor and a live region for approval state.
- Expose the code/file view toggle state with `aria-pressed`.

### Regression coverage

- Add frontend accessibility tests for service status, theme switch state, navigation semantics, skip-link wiring, and toggle state.

## Compatibility

- No visual redesign, API change, or workflow behavior change.
- Existing service polling and approval behavior are preserved.
- The changes are additive accessibility semantics and visible status labels.

## Verification

- `pnpm lint` passes.
- Frontend tests pass: `35 passed`.
- `pnpm build` passes, including the project’s existing `vue-tsc` build step.
- The base branch does not currently expose a separate `pnpm typecheck` script; the engineering-platform PR adds one for future CI coverage.

## Notes for maintainers

- This PR is intentionally scoped to status communication and accessibility semantics.
- It does not depend on the engineering-platform PR and can be reviewed independently.
